### PR TITLE
Graylog multilines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ $(if $(IS_WIN),$(error Windows is not supported in all recipes. Use WSL instead.
 SHELL := /bin/bash
 
 # Host machine IP
-export MACHINE_IP = $(shell source $(realpath $(CURDIR)/../../scripts/portable.sh) && get_this_ip)
+export MACHINE_IP = $(shell source $(realpath $(CURDIR)/scripts/portable.sh) && get_this_ip)
 
 include repo.config
 

--- a/services/graylog/docker-compose.yml
+++ b/services/graylog/docker-compose.yml
@@ -102,6 +102,9 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
       - ALLOW_TTY=true
+      - MULTILINE_MATCH=first
+      - MULTILINE_PATTERN='^(ERROR|WARNING|INFO|DEBUG|CRITICAL):'
+      - MULTILINE_ENABLE_DEFAULT=false
     deploy:
       mode: global
       resources:

--- a/services/graylog/docker-compose.yml
+++ b/services/graylog/docker-compose.yml
@@ -93,12 +93,12 @@ services:
   # Logspout: https://github.com/gliderlabs/logspout
   logspout:
     image: vincit/logspout-gelf
-    command: gelf://graylog:12201
+    command: multiline+gelf://graylog:12201
     depends_on:
       - graylog
     init: true
     volumes:
-      - /etc/hostname:/etc/host_hostname # does not work in windows
+     # - /etc/hostname:/etc/host_hostname # does not work in windows
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
       - ALLOW_TTY=true

--- a/services/minio/Makefile
+++ b/services/minio/Makefile
@@ -36,7 +36,7 @@ include .env
 include $(realpath $(CURDIR)/../../scripts/common.mk)
 
 .PHONY: up
-up: .init .env .create-stack-file .create-secrets ## Deploys or updates current stack "$(STACK_NAME)" using replicas=X (defaults to 1)
+up: .venv .init .env .create-stack-file .create-secrets ## Deploys or updates current stack "$(STACK_NAME)" using replicas=X (defaults to 1)
 	@docker stack deploy -c ${TEMP_COMPOSE} $(STACK_NAME)
 	@echo "in case you created more than 1 replicas, you need to label the nodes accordingly using"
 	@echo "'docker node update --label-add minioX=true' with X being from 1 to number of replicas."

--- a/services/simcore/docker-compose.deploy.yml
+++ b/services/simcore/docker-compose.deploy.yml
@@ -25,8 +25,9 @@ services:
         target: /usr/local/share/ca-certificates/osparc.crt
     environment:
       # minio sdk uses this env to use self-signed certs
-      - SSL_CERT_FILE: /usr/local/share/ca-certificates/osparc.crt
+      - SSL_CERT_FILE=/usr/local/share/ca-certificates/osparc.crt
       - LOGSPOUT_MULTILINE=true
+
     networks:
       - monitored
 

--- a/services/simcore/docker-compose.deploy.yml
+++ b/services/simcore/docker-compose.deploy.yml
@@ -15,6 +15,8 @@ services:
     networks:
       - public
       - monitored
+    environment:
+      - LOGSPOUT_MULTILINE=true
 
   # need to pass self-signed certificate in /usr/local/share/ca-certificates and call update-ca-certificates
   storage:
@@ -23,16 +25,34 @@ services:
         target: /usr/local/share/ca-certificates/osparc.crt
     environment:
       # minio sdk uses this env to use self-signed certs
-      SSL_CERT_FILE: /usr/local/share/ca-certificates/osparc.crt
+      - SSL_CERT_FILE: /usr/local/share/ca-certificates/osparc.crt
+      - LOGSPOUT_MULTILINE=true
     networks:
       - monitored
+
+  director:
+    environment:
+      - LOGSPOUT_MULTILINE=true
+  
+  apihub:
+    environment:
+      - LOGSPOUT_MULTILINE=true 
+
+  sidecar:
+    environment:
+      - LOGSPOUT_MULTILINE=true  
+
   rabbit:
     networks:
       - monitored
+    environment:
+      - LOGSPOUT_MULTILINE=true
 
   postgres:
     networks:
       - monitored
+    environment:
+      - LOGSPOUT_MULTILINE=true
   # in clusters one or more nodes are typically defined as THE postgres nodes.
   #   deploy:
   #     placement:

--- a/services/simcore/docker-compose.deploy.yml
+++ b/services/simcore/docker-compose.deploy.yml
@@ -1,5 +1,6 @@
 
 # LOGSPOUT_MULTILINE is used to tell to Logspoud, which is used by GrayLog, to handle multiline support of the logs of the concerned container.
+# See this issue to have more informations : https://github.com/ITISFoundation/osparc-ops/issues/40
 # osparc-simcore stack (framework stack)
 version: '3.7'
 services:

--- a/services/simcore/docker-compose.deploy.yml
+++ b/services/simcore/docker-compose.deploy.yml
@@ -1,3 +1,5 @@
+
+# LOGSPOUT_MULTILINE is used to tell to Logspoud, which is used by GrayLog, to handle multiline support of the logs of the concerned container.
 # osparc-simcore stack (framework stack)
 version: '3.7'
 services:


### PR DESCRIPTION

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Add a multi line support  for logs coming from the Simcore Stack, by adding some environment variables telling to Logspout (module used by Graylog to aggregates all the logs coming from the different containers) to use the multi line support when needed.

## Related issue number

<!-- Please add #issues -->
https://github.com/ITISFoundation/osparc-ops/issues/40

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] **Runs in the swarm**
- [ ] If you design a new module, add your user to .github/CODEOWNERS
