### PR TITLE
Remove `rollback_config`, add `failure_action: continue` to update_config

### DIFF
--- a/services/simcore/docker-compose.yml
+++ b/services/simcore/docker-compose.yml
@@ -7,11 +7,8 @@ services:
       update_config:
         parallelism: 2
         order: start-first
-        failure_action: rollback
+        failure_action: continue
         delay: 10s
-      rollback_config:
-        parallelism: 0
-        order: stop-first
       restart_policy:
         condition: any
         delay: 5s
@@ -33,11 +30,8 @@ services:
       update_config:
         parallelism: 2
         order: start-first
-        failure_action: rollback
+        failure_action: continue
         delay: 10s
-      rollback_config:
-        parallelism: 0
-        order: stop-first
       restart_policy:
         condition: any
         delay: 5s
@@ -62,11 +56,8 @@ services:
       update_config:
         parallelism: 2
         order: stop-first
-        failure_action: rollback
+        failure_action: continue
         delay: 10s
-      rollback_config:
-        parallelism: 0
-        order: stop-first
       restart_policy:
         condition: any
         delay: 5s
@@ -92,11 +83,8 @@ services:
       update_config:
         parallelism: 2
         order: start-first
-        failure_action: rollback
+        failure_action: continue
         delay: 10s
-      rollback_config:
-        parallelism: 0
-        order: stop-first
       restart_policy:
         condition: any
         delay: 5s
@@ -115,11 +103,8 @@ services:
       update_config:
         parallelism: 2
         order: start-first
-        failure_action: rollback
+        failure_action: continue
         delay: 10s
-      rollback_config:
-        parallelism: 0
-        order: stop-first
       restart_policy:
         condition: any
         delay: 5s
@@ -143,11 +128,8 @@ services:
       update_config:
         parallelism: 2
         order: start-first
-        failure_action: rollback
+        failure_action: continue
         delay: 10s
-      rollback_config:
-        parallelism: 0
-        order: stop-first
       restart_policy:
         condition: any
         delay: 5s
@@ -205,11 +187,8 @@ services:
       update_config:
         parallelism: 2
         order: start-first
-        failure_action: rollback
+        failure_action: continue
         delay: 10s
-      rollback_config:
-        parallelism: 0
-        order: stop-first
       restart_policy:
         condition: any
         delay: 5s
@@ -236,11 +215,8 @@ services:
       update_config:
         parallelism: 2
         order: start-first
-        failure_action: rollback
+        failure_action: continue
         delay: 10s
-      rollback_config:
-        parallelism: 0
-        order: stop-first
       restart_policy:
         condition: any
         delay: 5s
@@ -259,11 +235,8 @@ services:
       update_config:
         parallelism: 2
         order: start-first
-        failure_action: rollback
+        failure_action: continue
         delay: 10s
-      rollback_config:
-        parallelism: 0
-        order: stop-first
       restart_policy:
         condition: any
         delay: 5s
@@ -285,11 +258,8 @@ services:
       update_config:
         parallelism: 2
         order: start-first
-        failure_action: rollback
+        failure_action: continue
         delay: 10s
-      rollback_config:
-        parallelism: 0
-        order: stop-first
       restart_policy:
         condition: any
         delay: 5s
@@ -318,11 +288,8 @@ services:
       update_config:
         parallelism: 2
         order: start-first
-        failure_action: rollback
+        failure_action: continue
         delay: 10s
-      rollback_config:
-        parallelism: 0
-        order: stop-first
       restart_policy:
         condition: any
         delay: 5s
@@ -352,11 +319,8 @@ services:
       update_config:
         parallelism: 2
         order: start-first
-        failure_action: rollback
+        failure_action: continue
         delay: 10s
-      rollback_config:
-        parallelism: 0
-        order: stop-first
       restart_policy:
         condition: any
         delay: 5s
@@ -369,11 +333,8 @@ services:
       update_config:
         parallelism: 2
         order: start-first
-        failure_action: rollback
+        failure_action: continue
         delay: 10s
-      rollback_config:
-        parallelism: 0
-        order: stop-first
       restart_policy:
         condition: any
         delay: 5s
@@ -389,11 +350,8 @@ services:
       update_config:
         parallelism: 2
         order: start-first
-        failure_action: rollback
+        failure_action: continue
         delay: 10s
-      rollback_config:
-        parallelism: 0
-        order: stop-first
       restart_policy:
         condition: any
         delay: 5s
@@ -424,11 +382,8 @@ services:
       update_config:
         parallelism: 2
         order: start-first
-        failure_action: rollback
+        failure_action: continue
         delay: 10s
-      rollback_config:
-        parallelism: 0
-        order: stop-first
       restart_policy:
         condition: any
         delay: 5s
@@ -468,11 +423,8 @@ services:
       update_config:
         parallelism: 2
         order: start-first
-        failure_action: rollback
+        failure_action: continue
         delay: 10s
-      rollback_config:
-        parallelism: 0
-        order: stop-first
       restart_policy:
         condition: any
         delay: 5s
@@ -488,11 +440,8 @@ services:
       update_config:
         parallelism: 2
         order: start-first
-        failure_action: rollback
+        failure_action: continue
         delay: 10s
-      rollback_config:
-        parallelism: 0
-        order: stop-first
       restart_policy:
         condition: any
         delay: 5s
@@ -514,11 +463,8 @@ services:
       update_config:
         parallelism: 2
         order: start-first
-        failure_action: rollback
+        failure_action: continue
         delay: 10s
-      rollback_config:
-        parallelism: 0
-        order: stop-first
       restart_policy:
         condition: any
         delay: 5s
@@ -546,11 +492,8 @@ services:
       update_config:
         parallelism: 2
         order: start-first
-        failure_action: rollback
+        failure_action: continue
         delay: 10s
-      rollback_config:
-        parallelism: 0
-        order: stop-first
       restart_policy:
         condition: any
         delay: 5s
@@ -603,11 +546,8 @@ services:
       update_config:
         parallelism: 2
         order: start-first
-        failure_action: rollback
+        failure_action: continue
         delay: 10s
-      rollback_config:
-        parallelism: 0
-        order: stop-first
       restart_policy:
         condition: any
         delay: 5s
@@ -644,11 +584,8 @@ services:
       update_config:
         parallelism: 2
         order: start-first
-        failure_action: rollback
+        failure_action: continue
         delay: 10s
-      rollback_config:
-        parallelism: 0
-        order: stop-first
       restart_policy:
         condition: any
         delay: 5s
@@ -678,11 +615,8 @@ services:
       update_config:
         parallelism: 2
         order: start-first
-        failure_action: rollback
+        failure_action: continue
         delay: 10s
-      rollback_config:
-        parallelism: 0
-        order: stop-first
       restart_policy:
         condition: any
         delay: 5s


### PR DESCRIPTION
## What do these changes do?
We change the failure_action from `rollback` to `continue`, since rollback only makes sense during no-downtime updates (that we dont have atm) in any case. A rollback during a release is reprieved as confusing by some.

We now switch to the behavior `continue`, which means that after 5 unsuccessful starts of a docker service's replica, the task associated to the replica will stop trying to start containers, *without reverting and starting the previous container*. The task wills stay in state "failed".

I'll add that there is barely any official documentation available for the `failure_action` and thus I cannot provide good links for details. I did my research by reading the swarmkit sourcecode a bit and testing all `failure_actions` on my local machines.
## Related issue/s
https://github.com/ITISFoundation/osparc-ops-environments/issues/466
## Related PR/s
n/a
## Checklist
- [ ] ~~I tested and it works~~
- [x] I tested the behviour of the `failure_actions` on mock docker stacks on my machine
