### PR TITLE
Remove: graylog alert stack trace

### DIFF
--- a/services/graylog/data/contentpacks/osparc-custom-content-pack-v2.json
+++ b/services/graylog/data/contentpacks/osparc-custom-content-pack-v2.json
@@ -1,9 +1,9 @@
 {
   "v": "1",
-  "id": "daaeea11-bde6-4203-9cfe-6ca2a23ca22e",
-  "rev": 1,
-  "name": "osparc-custom-content-pack-v3",
-  "summary": "osparc-custom-content-pack-v3",
+  "id": "dfaeea11-bde6-4203-9cfe-6ca2a23ca22e",
+  "rev": 44,
+  "name": "osparc-custom-content-pack-v2",
+  "summary": "osparc-custom-content-pack-v2",
   "description": "",
   "vendor": "Osparc team",
   "url": "",
@@ -623,7 +623,7 @@
             "configuration": {
               "grok_pattern": {
                 "@type": "string",
-                "@value": "log_level=%{WORD:log_level} \\| log_timestamp=%{TIMESTAMP_ISO8601:log_timestamp} \\| log_source=%{DATA:log_source} \\| (log_uid=%{WORD:log_uid} \\| (log_oec=%{WORD:log_oec} \\| )?log_msg=%{GREEDYDATA:log_msg}"
+                "@value": "log_level=%{WORD:log_level} \\| log_timestamp=%{TIMESTAMP_ISO8601:log_timestamp} \\| log_source=%{NOTSPACE:log_source} \\| log_uid=%{NOTSPACE:log_uid} \\| log_oec=%{NOTSPACE:log_oec}\\| log_trace_id=%{NOTSPACE:log_trace_id} \\| (log_span_id=%{DATA:log_span_id}\\|)? log_msg=%{GREEDYDATA:log_msg}"
               },
               "named_captures_only": {
                 "@type": "boolean",


### PR DESCRIPTION
## What do these changes do?
Removes graylog stack traces alert
## Related issue/s

## Related PR/s
https://github.com/ITISFoundation/osparc-ops-environments/pull/1037
https://github.com/ITISFoundation/osparc-ops-environments/pull/118
## Checklist
- [ ] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode -->
