### PR TITLE
Metabase: add makefile up targets

### DIFF
--- a/services/metabase/Makefile
+++ b/services/metabase/Makefile
@@ -6,6 +6,16 @@ include ${REPO_BASE_DIR}/scripts/common-services.Makefile
 .PHONY: up
 up: ${TEMP_COMPOSE}  ## Deploys metabase stack
 
+up-aws: up
+
+up-master: up
+
+up-dalco: up
+
+up-local: up
+
+up-public: up
+
 ${TEMP_COMPOSE}: docker-compose.yml .env
 	@${REPO_BASE_DIR}/scripts/docker-stack-config.bash -e .env $< > $@
 


### PR DESCRIPTION
## What do these changes do?
CI calls up-<target> makefile target. Without these target CI will fail 

```bash
["make: *** No rule to make target 'up-master'.  Stop."]
```

## Related issue/s
* https://github.com/ITISFoundation/osparc-ops-environments/issues/1061

## Related PR/s
* https://github.com/ITISFoundation/osparc-ops-environments/pull/1093

## Checklist
- [ ] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker heathlcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
