### PR TITLE
Fix portainer makefile

### DIFF
--- a/services/portainer/Makefile
+++ b/services/portainer/Makefile
@@ -17,7 +17,6 @@ up: .init .env secrets ${TEMP_COMPOSE}
 	@docker stack deploy --with-registry-auth --prune --compose-file ${TEMP_COMPOSE} ${STACK_NAME}
 	@$(MAKE) --no-print-directory configure-portainer-registry
 
-
 .PHONY: up-local ## Deploys portainer stack for local deployment
 up-local: .init .env secrets ${TEMP_COMPOSE} ${TEMP_COMPOSE}-local
 	@docker stack deploy --with-registry-auth --prune --compose-file ${TEMP_COMPOSE}-local ${STACK_NAME}


### PR DESCRIPTION
## What do these changes do?
Spell correctly no print directory option of `make`

## Related issue/s

## Related PR/s
* Bug introduced in https://github.com/ITISFoundation/osparc-ops-environments/pull/1125

## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker heathlcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
