### PR TITLE
Fix uid for tempo datasource

### DIFF
--- a/services/monitoring/grafana/terraform/datasources.tf
+++ b/services/monitoring/grafana/terraform/datasources.tf
@@ -32,7 +32,7 @@ resource "grafana_data_source" "tempo" {
   url                = var.TEMPO_URL
   basic_auth_enabled = false
   is_default         = false
-  uid                = delr011tpeupsc
+  uid                = "delr011tpeupsc"
 }
 
 resource "grafana_data_source" "cloudwatch" {


### PR DESCRIPTION
## What do these changes do?
Hardcode the uid of the Tempo datasource. This seems to be the issue in #1156. I can see that other datasources which are referenced in dashboards have hardcoded uids. Once this is merged I will have to check that the rpc sections of the simcore service dashboards all work as expected.

## Related issue/s
- fixes #1156 
## Related PR/s

## Checklist
- [ ] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
