### PR TITLE
ensure graylog source is correct

### DIFF
--- a/services/logging/fluentd/fluent.conf
+++ b/services/logging/fluentd/fluent.conf
@@ -30,6 +30,8 @@
   @type forward
   port 24224
   bind 0.0.0.0
+  # Add source hostname to records
+  source_hostname_key source_hostname
 </source>
 
 # Add additional metadata
@@ -38,16 +40,18 @@
   <record>
     hostname "#{Socket.gethostname}"
     fluentd_hostname "#{ENV['FLUENTD_HOSTNAME']}"
-    tag ${tag}
   </record>
 </filter>
 
-# Clean container names (Ruby needed) by removing leading slashes
+# Clean container names and set proper host field
 <filter docker.**>
   @type record_transformer
   enable_ruby true
   <record>
+    # cleanup container names by removing leading slashes
     container_name ${record["container_name"] ? record["container_name"].sub(/^\//, '') : record["container_name"]}
+    # Use source hostname from forward input as the host field for GELF
+    host ${record["source_hostname"] || record["source"] || record["_hostname"] || "unknown"}
   </record>
 </filter>
 
@@ -64,6 +68,12 @@
     protocol udp
     add_msec_time true
     flush_interval 5s
+    # Use the host field from record for GELF host field
+    use_record_host true
+    # Map the correct fields for Graylog
+    <format>
+      @type json
+    </format>
     <buffer>
       @type file
       path /fluentd/buffer/graylog


### PR DESCRIPTION
## What do these changes do?
Ensure Graylog shows source as the real source hostname, not fluentd container hostname
## Related issue/s

## Related PR/s
* https://github.com/ITISFoundation/osparc-ops-environments/pull/1058
## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
