### PR TITLE
Metabase: remove ops auth and restrict password ⚠️

### DIFF
--- a/services/metabase/docker-compose.yml.j2
+++ b/services/metabase/docker-compose.yml.j2
@@ -23,8 +23,11 @@ services:
       - MB_DB_PASS=${METABASE_POSTGRES_PASSWORD}
       # https://www.metabase.com/docs/v0.54/installation-and-operation/running-metabase-on-docker#setting-the-java-timezone
       - JAVA_TIMEZONE=UTC
-      # https://www.metabase.com/docs/latest/installation-and-operation/observability-with-prometheus
+      # https://www.metabase.com/docs/v0.54/installation-and-operation/observability-with-prometheus
       - MB_PROMETHEUS_SERVER_PORT=9191
+      # https://www.metabase.com/docs/v0.54/people-and-groups/changing-password-complexity
+      - MB_PASSWORD_COMPLEXITY=strong
+      - MB_PASSWORD_LENGTH=20
     deploy:
       # https://www.metabase.com/learn/metabase-basics/administration/administration-and-operation/metabase-at-scale
       replicas: ${METABASE_REPLICAS}
@@ -49,7 +52,7 @@ services:
         - traefik.http.routers.metabase.entrypoints=https
         - traefik.http.routers.metabase.tls=true
         - traefik.http.middlewares.metabase_stripprefixregex.stripprefixregex.regex=^/metabase
-        - traefik.http.routers.metabase.middlewares=ops_whitelist_ips@swarm, ops_gzip@swarm, ops_auth@swarm, metabase_stripprefixregex
+        - traefik.http.routers.metabase.middlewares=ops_whitelist_ips@swarm, ops_gzip@swarm, metabase_stripprefixregex
         # service
         - traefik.http.services.metabase.loadbalancer.server.port=3000
         - traefik.http.services.metabase.loadbalancer.healthcheck.path=/api/health


### PR DESCRIPTION
## What do these changes do?
As per request from @calys, we remove ops auth. To compensate that, we stricten password requirements.

Actions required 🚨⚠️
* reset existing users's passwords to enforce new password requirements

## Related issue/s
* https://github.com/ITISFoundation/osparc-ops-environments/issues/1061

## Related PR/s
* aws master configuration update https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/merge_requests/1569
* prod https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/merge_requests/1570

## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
