### PR TITLE
Upgrade ops traefik to 3.5.2

### DIFF
--- a/services/traefik/docker-compose.yml.j2
+++ b/services/traefik/docker-compose.yml.j2
@@ -1,6 +1,6 @@
 services:
   traefik:
-    image: "traefik:v3.4.4"
+    image: "traefik:v3.5.2"
     init: true
     dns: 8.8.8.8
     healthcheck:


### PR DESCRIPTION
## What do these changes do?
We need update to avoid bug introduced in 3.4.4. Read more in related issue

## Related issue/s
* https://github.com/ITISFoundation/osparc-ops-environments/issues/1199

## Related PR/s
* https://github.com/ITISFoundation/osparc-simcore/pull/8343

## Checklist
- [ ] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
