### PR TITLE
Revert: disable loki & vector-dev, oldschool graylog logging

### DIFF
--- a/certificates/Makefile
+++ b/certificates/Makefile
@@ -66,10 +66,16 @@ install-root-certificate: rootca.crt ## installs a certificate in the host syste
 		echo "Is the DOCKER service ready? press when ready" && read -n 1; \
 	    fi;\
 		echo "======================================";,\
-		sudo cp $< /etc/ca-certificates/trust-source/anchors/osparc.crt; \
-		sudo trust extract-compat &&                            \
-		echo "# restarting docker daemon" &&                      \
+		$(if $(IS_OSX),                                             \
+			sudo security add-trusted-cert -d -k /Library/Keychains/System.keychain $<; \
+			echo "Please restart the DOCKER service now..." && read -n 1; \
+			echo "Is the DOCKER service ready? press when ready" && read -n 1; \
+		,                                                           \
+		sudo cp $< /usr/local/share/ca-certificates/osparc.crt; \
+		sudo update-ca-certificates -f;                            \
+		echo "# restarting docker daemon";                      \
 		sudo systemctl restart docker                           \
+		) \
 	)
 
 
@@ -84,8 +90,7 @@ remove-root-certificate: ## removes the certificate from the host system
 		$(if $(IS_OSX), \
 			sudo security remove-trusted-cert -d rootca.crt; \
 		, \
-		sudo rm -f /etc/ca-certificates/trust-source/anchors/osparc.crt; \
-		sudo trust extract-compat; \
-		sudo systemctl restart docker; \
+		sudo rm -f /usr/local/share/ca-certificates/osparc.crt; \
+		sudo update-ca-certificates -f; \
 		) \
 	)


### PR DESCRIPTION
## What do these changes do?
There are still missing logs in aws deployments that use the new logging stack, and it is today (prod release) not clear why. In a conservative approach, we revert to the old-style of passing around logs, namely the docker-daemon sending directly with `udp` to `graylog`.

The revert works by switching around host-connected udp ports.
To be safe, loki and vector-dev are scaled to 0 replicas
## Related issue/s

## Related PR/s

## Checklist
- [ ] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
