### PR TITLE
🐛 Remove probabilistic sampler processor from otel collector

### DIFF
--- a/services/jaeger/opentelemetry-collector-config.yaml
+++ b/services/jaeger/opentelemetry-collector-config.yaml
@@ -17,7 +17,7 @@ service:
     traces:
       receivers: [otlp]
       exporters: [otlphttp,otlp]
-      processors: [batch,probabilistic_sampler,filter/drop_healthcheck]
+      processors: [batch,filter/drop_healthcheck]
   telemetry:
     logs:
       level: ${TRACING_OPENTELEMETRY_COLLECTOR_SERVICE_TELEMETRY_LOG_LEVEL}


### PR DESCRIPTION
## What do these changes do?
- It seems https://github.com/ITISFoundation/osparc-ops-environments/pull/1230 broke the config of the otel collector.

## Related issue/s
- On master deployments we currently see the following error log in the otel collector
```console
Error: invalid configuration: service::pipelines::traces: references processor "probabilistic_sampler" which is not configured

2025/10/10 09:23:29 collector server run finished with error: invalid configuration: service::pipelines::traces: references processor "probabilistic_sampler" which is not configured
```
## Related PR/s
- https://github.com/ITISFoundation/osparc-ops-environments/pull/1230
## Checklist
- [ ] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
