### PR TITLE
Kubernetes: fix global network policy

### DIFF
--- a/charts/calico-configuration/README.md
+++ b/charts/calico-configuration/README.md
@@ -15,6 +15,7 @@ if calico version 3.30+ is installed
 
 if calico version <= 3.29
 * create network policy with action log (read more https://docs.tigera.io/calico/latest/network-policy/policy-rules/log-rules)
+* WARNING: these logs are shown in journalctl **of the node where restricted workload (POD / Container) is running**
   ```yaml
   apiVersion: projectcalico.org/v3
   kind: NetworkPolicy

--- a/charts/calico-configuration/templates/globalpolicy.yaml
+++ b/charts/calico-configuration/templates/globalpolicy.yaml
@@ -26,10 +26,11 @@ spec:
     # IP from https://github.com/kubernetes-sigs/kubespray/blob/v2.24.1/roles/kubespray-defaults/defaults/main/main.yml#L108
     - action: Allow
       protocol: UDP
-      nets:
-        - 169.254.25.10/32
-      ports:
-        - 53
+      destination:
+        nets:
+          - 169.254.25.10/32
+        ports:
+          - 53
     - action: Allow
       protocol: TCP
       destination:
@@ -38,7 +39,8 @@ spec:
           - 53
     - action: Allow
       protocol: TCP
-      nets:
-        - 169.254.25.10/32
-      ports:
-        - 53
+      destination:
+        nets:
+          - 169.254.25.10/32
+        ports:
+          - 53

--- a/charts/simcore-charts/resource-usage-tracker/templates/networkpolicy.yaml
+++ b/charts/simcore-charts/resource-usage-tracker/templates/networkpolicy.yaml
@@ -25,18 +25,20 @@ spec:
     - action: Allow
       protocol: TCP
       destination:
-        nets:
-          - 10.0.0.0/8
-          - 192.168.0.0/16
-          - 172.16.0.0/12
+        # currently public IPs are used
+        # nets:
+        #   - 10.0.0.0/8
+        #   - 192.168.0.0/16
+        #   - 172.16.0.0/12
         ports:
           - {{ .Values.networkPolicyEgressPorts.redis }}
     - action: Allow
       protocol: TCP
       destination:
-        nets:
-          - 10.0.0.0/8
-          - 192.168.0.0/16
-          - 172.16.0.0/12
+        # currently public IPs are used
+        # nets:
+        #   - 10.0.0.0/8
+        #   - 192.168.0.0/16
+        #   - 172.16.0.0/12
         ports:
           - {{ .Values.networkPolicyEgressPorts.rabbit }}


### PR DESCRIPTION
## What do these changes do?
global network policy was misconfigured so that it allowed all traffic. By setting correct value structure this is fixed.

Proper global network policy discovered a wrong RUT network policy that was correctly adjusted.

Bonus:
* Imrpove calico network policy debug documentation


## Related issue/s
* closes https://github.com/ITISFoundation/osparc-ops-environments/issues/1226

## Related PR/s

## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
