### PR TITLE
Revert "RabbitMQ Cluster: make `quorum` default queue type"

### DIFF
--- a/services/rabbit/configs/rabbitmq.conf.j2
+++ b/services/rabbit/configs/rabbitmq.conf.j2
@@ -23,7 +23,3 @@ quorum_queue.initial_cluster_size = {{ RABBIT_QUORUM_QUEUE_DEFAULT_REPLICA_COUNT
 # https://www.rabbitmq.com/docs/networking#proxy-protocol
 # WARNING: this forces clients to use a proxy (direct access to nodes does not work)
 proxy_protocol = true
-
-# Set the default queue type to quorum to benefit from RabbitMQ Cluster
-# (to be highly available by default). This does not enforce queue type though
-default_queue_type = quorum


### PR DESCRIPTION
We use celery 5.1 that does not support Quorum queues (see [github issue](https://github.com/celery/celery/issues/6067)). We need to find a solution for this (esp. `api_worker_queue`) before making quorum default queue type.

One of the ways is to update celery to 5.5


