### PR TITLE
Kubernetes makefile: add usage example

### DIFF
--- a/charts/Makefile
+++ b/charts/Makefile
@@ -11,8 +11,14 @@ include $(REPO_CONFIG_LOCATION)
 export CONFIG_DIR := $(shell dirname $(REPO_CONFIG_LOCATION))
 CHART_DIRS := $(wildcard $(REPO_BASE_DIR)/charts/*/)
 
+# Example of usage:
+# make helmfile-diff HELMFILE_EXTRA_ARGS='--selector app=adminer'
 HELMFILE_EXTRA_ARGS ?=
 HELMFILE := helmfile $(HELMFILE_EXTRA_ARGS)
+
+#
+# Targets
+#
 
 .PHONY: .check-helmfile-installed
 .check-helmfile-installed: ## Checks if helmfile is installed


### PR DESCRIPTION
## What do these changes do?
Document how to target particular releases (apps) with helmfile command

## Related issue/s

## Related PR/s
* https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/merge_requests/1640
* https://github.com/ITISFoundation/osparc-ops-environments/pull/1234

## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
