### PR TITLE
:bug: Fix: graylog dashboard processing

### DIFF
--- a/services/logging/vector.yaml
+++ b/services/logging/vector.yaml
@@ -60,7 +60,7 @@ transforms:
         .service_name = "unknown"
       }
       .log_service = .service_name
-      
+
       # Handle container ID
       if exists(._container_id) {
         .container_id = ._container_id


### PR DESCRIPTION
## What do these changes do?
Fixes the graylog simcore log-analysis dashboards by having vector-dev prepare the required `log_service` field. Since vector-dev already sets this, no special graylog-extractor to determine the docker service name from the container name is required.

This was tested on osparc-master.speag.com successfully (dashboard worked)
## Related issue/s
https://github.com/ITISFoundation/osparc-ops-environments/issues/1245
## Related PR/s
https://github.com/ITISFoundation/osparc-ops-environments/pull/1243
## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
