### PR TITLE
maintenance pages: add ha setup :warning: 

### DIFF
--- a/services/maintenance-page/docker-compose.yml.j2
+++ b/services/maintenance-page/docker-compose.yml.j2
@@ -21,9 +21,12 @@ services:
       - public
       - monitored
     deploy:
+      replicas: 2
       placement:
         constraints:
           - node.labels.ops==true
+        preferences:
+          - spread: node.labels.ops
       labels:
         - traefik.enable=true
         - traefik.swarm.network=${PUBLIC_NETWORK}
@@ -46,9 +49,12 @@ services:
       - public
       - monitored
     deploy:
+      replicas: 2
       placement:
         constraints:
           - node.labels.ops==true
+        preferences:
+          - spread: node.labels.ops
       labels:
           - traefik.enable=true
           - traefik.swarm.network=${PUBLIC_NETWORK}


### PR DESCRIPTION
## What do these changes do?
Run 2 replicas of each service and spread replicas across OPS nodes.

Placement preferences documentation: https://docs.docker.com/reference/compose-file/deploy/#preferences

## Related issue/s
* https://github.com/ITISFoundation/osparc-simcore/issues/8432#issuecomment-3484250937

## Related PR/s

## ToDo
- [ ] Check maintenance pages work properly in nih staging

## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
