### PR TITLE
Rabbit Cluster: configure default queue type :warning: 

### DIFF
--- a/services/rabbit/configs/rabbitmq.conf.j2
+++ b/services/rabbit/configs/rabbitmq.conf.j2
@@ -23,3 +23,7 @@ quorum_queue.initial_cluster_size = {{ RABBIT_QUORUM_QUEUE_DEFAULT_REPLICA_COUNT
 # https://www.rabbitmq.com/docs/networking#proxy-protocol
 # WARNING: this forces clients to use a proxy (direct access to nodes does not work)
 proxy_protocol = true
+
+# Set the default queue type to quorum to benefit from RabbitMQ Cluster
+# (to be highly available by default). This does not enforce queue type though
+default_queue_type = quorum


### PR DESCRIPTION
## What do these changes do?
Use quorum by default. This is reasonable as `durable` queues need to be quorum for HA purposes. If not configured, `durable` queues end up `classic` which breaks HA. 

More context on HA, durable and classic queues https://github.com/rabbitmq/rabbitmq-server/discussions/14763

## RabbitMQ Queue Type behavior
default virtual host queue type `classic`:
* durable --> classic

default virtual host queue type `quorum`:
* durable --> quorum
* no param --> classic
* durable & auto_delete --> classic

There are params that are not compatible with `quorum` queues, so that using them always produces `classic` queue (.e.g. `exclusive`, `auto_delete`). 

There is also nice analysis (done by AI so that everything needs to be double checked!) https://deepwiki.com/rabbitmq/rabbitmq-server/3.1-queue-types#queue-type-selection-and-declaration

## Related issue/s
* https://github.com/ITISFoundation/osparc-ops-environments/issues/1232

## Related PR/s
* simcore queue configuration changes https://github.com/ITISFoundation/osparc-simcore/pull/8573
* reimplements reverted https://github.com/ITISFoundation/osparc-ops-environments/pull/1238

## Manual actions :warning: 
How to change on existing clusters (currently only internal master)

```bash
rabbitmqctl update_vhost_metadata / --default-queue-type quorum
```

## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
