### PR TITLE
Setup grafana datasource links

### DIFF
--- a/services/monitoring/grafana/terraform/datasources.tf
+++ b/services/monitoring/grafana/terraform/datasources.tf
@@ -59,7 +59,7 @@ resource "grafana_data_source" "loki" {
       {
         datasourceUid = "tempo"
         matcherType   = "label"
-        matcherRegex  = "log_trace_id"
+        matcherRegex  = "^log_trace_id$"
         name          = "TraceID"
         url           = "$${__value.raw}"
       }


### PR DESCRIPTION
## What do these changes do?
- Configure Grafana datasource links (traces->logs and logs->traces)
- Precise details and screen shots are available in the linkes PR below
## Related issue/s

## Related PR/s
- https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/merge_requests/1663

## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
