### PR TITLE
Improve vector log processing

### DIFF
--- a/services/logging/vector.yaml
+++ b/services/logging/vector.yaml
@@ -90,7 +90,7 @@ transforms:
       }
 
       # Add processing metadata
-      .processed_by = "vector-dev"
+      .processed_by = "vector"
 
 sinks:
   # Send to Loki over TCP


### PR DESCRIPTION
## What do these changes do?
Improve vector's processing of logs to improve user experience in Loki. More precisely, as discussed with @mrnicegyu11, this updates the vector log processing in the following ways:
- When ever a log has a well-defined `level` (as specified by the `log_level`), this is added as a label to the log message. Otherwise `level="UNKNOWN"` is set. This is done in order to avoid that Loki doesn't try to guess the log level (which doesn't seem to work very well for our logs).
- `\n` are resolved to display new lines in the log. This makes the reading of logs in loki much easier.
- If a `log_msg` is not found in the log (e.g. because it is a log line which is generated before the proper log formatting is setup inside our simcore services) then `log_msg=msg` in order to ensure that a message will be displayed in loki. 

## Related issue/s

## Related PR/s

## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
