### PR TITLE
Fix graylog log processing incompatibility

### DIFF
--- a/services/logging/vector.yaml
+++ b/services/logging/vector.yaml
@@ -15,7 +15,7 @@ sources:
 
 transforms:
   # Process and enrich the logs
-  process_logs:
+  process_logs_base:
     type: remap
     inputs: ["docker_gelf"]
     source: |
@@ -23,43 +23,6 @@ transforms:
       # Map short_message to message for Loki compatibility
       if exists(.short_message) {
         .message = .short_message
-      }
-
-      # Extract structured log fields from message using regex pattern
-      if exists(.message) {
-        # python service logs
-        parsed_fields, err = parse_regex(.message, r'log_level=(?P<log_level>[^|]*) \| log_timestamp=(?P<log_timestamp>[^|]*) \| log_source=(?P<log_source>[^|]*) \| log_uid=(?P<log_uid>[^|]*) \| log_oec=(?P<log_oec>[^|]*) \| log_trace_id=(?P<log_trace_id>[^|]*) \| log_span_id=(?P<log_span_id>[^|]*) \| log_msg=(?P<log_msg>.*)$')
-        # traefik logs
-        traefik_fields, traefik_err = parse_regex(.message, r'time="(?P<log_timestamp>[^"]*)" level=(?P<log_level>\w+) msg="(?P<log_msg>.*)"')
-        if err == null {
-          .log_level = parsed_fields.log_level
-          .log_timestamp = parsed_fields.log_timestamp
-          .log_source = parsed_fields.log_source
-          .log_uid = parsed_fields.log_uid
-          .log_oec = parsed_fields.log_oec
-          .log_trace_id = parsed_fields.log_trace_id
-          .log_span_id = parsed_fields.log_span_id
-          .log_msg = parsed_fields.log_msg
-        } else if traefik_err == null {
-          .log_timestamp = traefik_fields.log_timestamp
-          .log_level = traefik_fields.log_level
-          .log_msg = traefik_fields.log_msg
-        } else {
-          .log_msg = .message
-        }
-
-        log_msg_processed = replace!(.log_msg, "\\n", "
-        ")
-        if log_msg_processed != null {
-          .log_msg = log_msg_processed
-        }
-      }
-
-      # ensure level is set for Grafana/Loki to color the log correctly
-      if exists(.log_level){
-        .level = .log_level
-      } else {
-        .level = "UNKNOWN"
       }
 
       # Handle container name - GELF uses _container_name (with underscore prefix)
@@ -92,11 +55,55 @@ transforms:
       # Add processing metadata
       .processed_by = "vector"
 
+  process_logs_loki:
+    type: "remap"
+    inputs: ["process_logs_base"]
+    source: |
+
+      # Extract structured log fields from message using regex pattern
+      if exists(.message) {
+        # python service logs
+        parsed_fields, err = parse_regex(.message, r'log_level=(?P<log_level>[^|]*) \| log_timestamp=(?P<log_timestamp>[^|]*) \| log_source=(?P<log_source>[^|]*) \| log_uid=(?P<log_uid>[^|]*) \| log_oec=(?P<log_oec>[^|]*) \| log_trace_id=(?P<log_trace_id>[^|]*) \| log_span_id=(?P<log_span_id>[^|]*) \| log_msg=(?P<log_msg>.*)$')
+        # traefik logs
+        traefik_fields, traefik_err = parse_regex(.message, r'time="(?P<log_timestamp>[^"]*)" level=(?P<log_level>\w+) msg="(?P<log_msg>.*)"')
+        if err == null {
+          .log_level = parsed_fields.log_level
+          .log_timestamp = parsed_fields.log_timestamp
+          .log_source = parsed_fields.log_source
+          .log_uid = parsed_fields.log_uid
+          .log_oec = parsed_fields.log_oec
+          .log_trace_id = parsed_fields.log_trace_id
+          .log_span_id = parsed_fields.log_span_id
+          .log_msg = parsed_fields.log_msg
+        } else if traefik_err == null {
+          .log_timestamp = traefik_fields.log_timestamp
+          .log_level = traefik_fields.log_level
+          .log_msg = traefik_fields.log_msg
+        } else {
+          .log_msg = .message
+        }
+
+        log_msg_processed = replace!(.log_msg, "\\n", "
+        ")
+        if log_msg_processed != null {
+          .log_msg = log_msg_processed
+        }
+      }
+
+      # ensure level field is set for Grafana Loki
+      if exists(.log_level){
+        .level = .log_level
+      } else {
+        .level = "UNKOWN"
+      }
+
+
+
 sinks:
   # Send to Loki over TCP
   loki:
     type: loki
-    inputs: ["process_logs"]
+    inputs: ["process_logs_loki"]
     endpoint: "http://${VECTOR_LOG_DESTINATION:?err}:12204"
     encoding:
       codec: json
@@ -112,7 +119,7 @@ sinks:
   # Send to Graylog via GELF over TCP
   graylog:
     type: socket
-    inputs: ["process_logs"]
+    inputs: ["process_logs_base"]
     address: "${VECTOR_LOG_DESTINATION:?err}:12203"
     mode: tcp
     encoding:


### PR DESCRIPTION
## What do these changes do?
- Vector stopped processing logs with the following error
```
2025-11-17T07:04:53.221877Z ERROR sink{component_kind="sink" component_id=graylog component_type=socket}: vector::internal_events::codecs: Failed serializing frame. error=LogEvent contains a value with an invalid type. field = "level" type = "string" expected type = "integer" error_code="encoder_serialize" error_type="encoder_failed" stage="sending" internal_log_rate_limit=true
```
- Apparently the issue is that graylog doesn't allow a field `.level` with a string value (it is required to be an int). 
- This PR fixes the issue by splitting the log processing in vector into two different stages: A base and one specialized for Loki.

## Related issue/s

## Related PR/s

## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
