### PR TITLE
Kubernetes victoria logs: optional HA mode

### DIFF
--- a/charts/victoria-logs/values.ha.yaml.gotmpl
+++ b/charts/victoria-logs/values.ha.yaml.gotmpl
@@ -1,0 +1,4 @@
+server:
+  # HA trough multiple replicas
+  # https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9076
+  replicaCount: 2

--- a/charts/victoria-logs/values.yaml.gotmpl
+++ b/charts/victoria-logs/values.yaml.gotmpl
@@ -6,9 +6,7 @@ vector:
   enabled: true
 
 server:
-  # HA trough multiple replicas
-  # https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9076
-  replicaCount: 2
+  replicaCount: 1
 
   retentionPeriod: 30d
 


### PR DESCRIPTION
## What do these changes do?
By default we run non-ha mode. It requires less resources. If necessary, enable HA mode via `./values.ha.yaml.gotmpl`

## Related issue/s

## Related PR/s
* configuration https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/merge_requests/1687

## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
