### PR TITLE
Fix helm linting of victoria metrics distirbuted

### DIFF
--- a/charts/victoria-metrics-distributed/templates/grafana/dashboards.yaml
+++ b/charts/victoria-metrics-distributed/templates/grafana/dashboards.yaml
@@ -29,6 +29,6 @@ data:
   dashboard.json: | {{ tpl (.Files.Get $dashboardFilePath) . | nindent 4 }}
 ---
 
-# Avoid strippint whitespaces (aka `{{- end }}`) due to https://github.com/helm/helm/issues/10149#issuecomment-929205040
+# Avoid stripping whitespaces due to https://github.com/helm/helm/issues/10149#issuecomment-929205040
 {{ end }}
 {{ end }}


### PR DESCRIPTION
## What do these changes do?
`dashboards.yaml` generates dynamically content. It works with helm template but fails with helm lint. Read more https://github.com/helm/helm/issues/10149#issuecomment-929205040

## Related issue/s

## Related PR/s
* https://github.com/ITISFoundation/osparc-ops-environments/pull/1270

## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
