### PR TITLE
Add notifications worker service

### DIFF
--- a/services/simcore/docker-compose.yml.j2
+++ b/services/simcore/docker-compose.yml.j2
@@ -1103,7 +1103,7 @@ services:
     networks:
       - monitored
     deploy:
-      replicas: ${SIMCORE_NOTIFICATIONS_WRK_REPLICAS}
+      replicas: ${SIMCORE_NOTIFICATIONS_WORKER_REPLICAS}
       placement:
         constraints:
           - node.labels.simcore==true


### PR DESCRIPTION
## What do these changes do?

until @giancarloromeo provides numbers for resource limits and reservations --> @YuryHrytsuk estimated first numbers we can start with

## Related issue/s
* closes https://github.com/ITISFoundation/osparc-ops-environments/issues/1277

## Related PR/s
* https://github.com/ITISFoundation/osparc-simcore/pull/8615
* configuration https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/merge_requests/1701
* update grafana https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/merge_requests/1706

## Checklist
- [ ] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

- [x] Service has resource limits and reservations
- [x] Service has placement constraints or is global
- [x] Service is restartable @giancarloromeo 
- [x] Service restart is zero-downtime @giancarloromeo 
- [x] Service has >1 replicas in PROD
- [x] Service has docker healthcheck enabled @giancarloromeo 
- [x] Service is monitored (via prometheus and grafana)
- [x] Service is not bound to one specific node (e.g. via files or volumes)
- [x] Relevant OPS E2E Test are added --> no extra tests necessary
- [x] Grafana dashboards updated accordingly
