### PR TITLE
Rabbit Cluster: update rabbit image version :warning: :rotating_light: 

### DIFF
--- a/services/rabbit/docker-compose.node0x.yml.j2
+++ b/services/rabbit/docker-compose.node0x.yml.j2
@@ -1,6 +1,6 @@
 services:
   rabbit0{{ NODE_INDEX }}:
-    image: itisfoundation/rabbitmq:4.1.2-management
+    image: itisfoundation/rabbitmq:4.1.6-management
     init: true
     # https://docs.docker.com/reference/cli/docker/service/create/#create-services-using-templates
     hostname: {% raw %}"{{.Service.Name}}"{% endraw %}


### PR DESCRIPTION
## What do these changes do?

Manual actions :warning: 
* update rabbit cluster node is required while deploying this change

## Related issue/s

## Related PR/s
* https://github.com/ITISFoundation/dockerfiles/pull/91

## Checklist
- [ ] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
