### PR TITLE
simcore notifications service: update cpu limit

### DIFF
--- a/services/simcore/docker-compose.yml.j2
+++ b/services/simcore/docker-compose.yml.j2
@@ -1094,7 +1094,7 @@ services:
       resources:
         limits:
           memory: 500M
-          cpus: '0.5'
+          cpus: '1'
         reservations:
           memory: 50M
           cpus: '0.1'


### PR DESCRIPTION
## What do these changes do?
`0.5` is not enough. service is constantly throttled and healthcheck fails. It works with `1` CPU limit.

@giancarloromeo @sanderegg I still find it wrong that service with zero activity cannot start with `0.5` CPU limit

## Related issue/s
- mitigates https://github.com/ITISFoundation/osparc-simcore/issues/8674

## Related PR/s
- [x] add notifications to simcore services grafana dashboard https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/merge_requests/1705

## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
