### PR TITLE
Add Prometheus scraping of chatbot

### DIFF
--- a/services/vendors/docker-compose.yml.j2
+++ b/services/vendors/docker-compose.yml.j2
@@ -65,8 +65,11 @@ services:
         - traefik.http.routers.vendor_chat_backend.tls=true
         - traefik.http.routers.vendor_chat_backend.rule=(PathPrefix(`/v1/`) && ({{ generate_vendors_traefik_rule(VENDOR_CHATBOT_PRODUCTS, VENDOR_CHATBOT_SUBDOMAIN_PREFIX) }}))
         - traefik.http.routers.vendor_chat_backend.middlewares=authenticated_platform_user@swarm
+        - prometheus-job=vendor_chat_backend
+        - prometheus-port=${VENDOR_CHATBOT_BACKEND_PORT}
     networks:
       - public
+      - monitored_network
 networks:
   public:
     external: true


### PR DESCRIPTION
## What do these changes do?
- Add scraping of chatbot to prometheus
- This is done directly in the docker compose config of the chatbot.
- The chatbot is also added to the monitoring network in order for prometheus to reach him.

## Related issue/s

## Related PR/s

## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
