### PR TITLE
Fix simcore stack generation

### DIFF
--- a/services/simcore/Makefile
+++ b/services/simcore/Makefile
@@ -5,6 +5,7 @@ include ${REPO_BASE_DIR}/scripts/common-services.Makefile
 # relies on STACK_NAME var which is defined in common-services.Makefile
 include ${REPO_BASE_DIR}/scripts/common.Makefile
 
+TEMP_COMPOSE=docker-compose.deploy.yml  # special case in simcore. This name is hardcoded in scripts used
 SIMCORE_REPO_DIR ?= $(abspath $(REPO_BASE_DIR)/../osparc-simcore)
 
 $(SIMCORE_REPO_DIR):


### PR DESCRIPTION
## What do these changes do?
simcore stack is a special case. bash scripts hard code temp compose file.
so we must keep it special until scripts are refactored.

It fixes deploy simcore CI. It fails now as generated stack file is empty.

## Related issue/s

## Related PR/s
* bug was introduced in https://github.com/ITISFoundation/osparc-ops-environments/pull/1299/

## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
