### PR TITLE
Avoid extra j2 logs

### DIFF
--- a/scripts/common.Makefile
+++ b/scripts/common.Makefile
@@ -384,7 +384,7 @@ endef
 else
 
 define jinja
-	${VENV_BIN}/j2 --quiet --format=env $(1) $(2) -o $(3) \
+	${VENV_BIN}/j2 --format=env $(1) $(2) -o $(3) \
 	--filters $(REPO_BASE_DIR)/scripts/j2cli_global_filters.py \
 	--quiet
 endef


### PR DESCRIPTION
## What do these changes do?
Every time we use jinja in Makefile scripts, we get info logs about jinja version (see below). This PR removes such logs.

```
j2 25.3.1, Jinja2 3.1.6
```
## Related issue/s

## Related PR/s
* https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/merge_requests/1658/
* https://github.com/ITISFoundation/osparc-ops-environments/pull/1254

## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
