### PR TITLE
Simcore stack: implement down Makefile target

### DIFF
--- a/scripts/common.Makefile
+++ b/scripts/common.Makefile
@@ -196,7 +196,7 @@ help:
 .PHONY: down-default
 down-default: ## Removes the stack from the swarm
 	@echo "${STACK_NAME}"
-	@docker stack rm ${STACK_NAME}
+	@docker stack rm --detach=false ${STACK_NAME}
 
 .PHONY: leave
 leave: ## Leaves swarm stopping all services in it

--- a/services/simcore/Makefile
+++ b/services/simcore/Makefile
@@ -97,3 +97,8 @@ ${TEMP_COMPOSE}-master: docker-compose.yml docker-compose.deploy.master.yml
 	echo DEPLOYMENT_FQDNS_CAPTURE_STORAGE=\''${DEPLOYMENT_FQDNS_CAPTURE_STORAGE}'\' >> .env; \
 	echo DOLLAR=\'$$\' >> .env; \
 	set +o allexport; \
+
+down:
+	@# override default implementation as stack name is defined in the config file
+	@set -a && source $(REPO_CONFIG_LOCATION) && set +a && \
+	docker stack rm --detach=false $$SIMCORE_STACK_NAME


### PR DESCRIPTION
## What do these changes do?
Extra
* make `--detach=false` default for service shutdown

## Related issue/s
* https://github.com/ITISFoundation/osparc-ops-environments/issues/1310
  - in case we want to use `make down` for each docker stack we run
  
## Related PR/s

## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
