### PR TITLE
dalco: keep simcore rabbit if configured

### DIFF
--- a/services/simcore/docker-compose.deploy.dalco.yml
+++ b/services/simcore/docker-compose.deploy.dalco.yml
@@ -43,6 +43,3 @@ services:
     payments:
         deploy:
             replicas: 0
-    rabbit:
-        deploy:
-            replicas: 0  # use standalone (cluster) rabbit stack


### PR DESCRIPTION
## What do these changes do?
We are not ready to propagate self-hosted cluster rabbit to PROD until https://git.speag.com/oSparc/osparc-infra/-/issues/88 is resolved.

We keep self-hosted cluster rabbit in dalco stag but in PROD use goold old rabbit from simcore stack (this is configure via setting simcore rabbit replicas to `0` / `1`)

FYI: @sanderegg @matusdrobuliak66 

## Related issue/s
* https://git.speag.com/oSparc/osparc-infra/-/issues/88
* https://github.com/ITISFoundation/osparc-ops-environments/issues/1176

## Related PR/s
* https://github.com/ITISFoundation/osparc-ops-environments/pull/1262

## Checklist
- [ ] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
