### PR TITLE
Parse `log_trace_sampled` in vector-dev config (logging stack)

### DIFF
--- a/services/logging/vector.yaml.j2
+++ b/services/logging/vector.yaml.j2
@@ -81,6 +81,7 @@ transforms:
           .log_oec = parsed_fields.log_oec
           .log_trace_id = parsed_fields.log_trace_id
           .log_span_id = parsed_fields.log_span_id
+          .log_trace_sampled = parsed_fields.log_trace_sampled
           .log_msg = parsed_fields.log_msg
         } else if traefik_err == null {
           .log_timestamp = traefik_fields.log_timestamp


### PR DESCRIPTION
## What do these changes do?
This pull request updates the log parsing regex for Python service logs in the `vector.yaml.j2` configuration to extract an additional field, `log_trace_sampled`, from the log messages. This change improves the structured logging by capturing more trace-related information.

Log parsing improvements:

* Updated the regex pattern in the `transforms` section of `services/logging/vector.yaml.j2` to extract a new field, `log_trace_sampled`, from Python service logs.

## Related issue/s
- https://github.com/ITISFoundation/osparc-simcore/pull/8736

## Related PR/s

## Checklist
- [ ] I tested and it works
- There is a test on the osparc-simcore side which checks that the parsing with this regex pattern is correct.
<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
