### PR TITLE
simcore services: add configurable replicas

### DIFF
--- a/services/simcore/docker-compose.deploy.aws.yml
+++ b/services/simcore/docker-compose.deploy.aws.yml
@@ -34,10 +34,6 @@ services:
     deploy:
       replicas: 1
 
-  wb-api-server:
-    deploy:
-      replicas: 3
-
   rabbit:
     deploy:
       labels:

--- a/services/simcore/docker-compose.deploy.dalco.yml
+++ b/services/simcore/docker-compose.deploy.dalco.yml
@@ -32,14 +32,14 @@ services:
                 - traefik.tcp.routers.${SWARM_STACK_NAME}_postgresRoute.service=${SWARM_STACK_NAME}_postgresRoute
                 - traefik.tcp.services.${SWARM_STACK_NAME}_postgresRoute.loadbalancer.server.port=5432
                 - "traefik.tcp.routers.${SWARM_STACK_NAME}_postgresRoute.rule=ClientIP(`195.176.8.0/24`) || ClientIP(`10.0.0.0/8`) || ClientIP(`172.16.0.0/12`) || ClientIP(`192.168.0.0/16`)"
+
     wb-garbage-collector:
         hostname: "{{.Service.Name}}"
-    wb-api-server:
-        deploy:
-            replicas: 3
+
     clusters-keeper:
         deploy:
             replicas: 0
+
     payments:
         deploy:
             replicas: 0

--- a/services/simcore/docker-compose.deploy.local.yml
+++ b/services/simcore/docker-compose.deploy.local.yml
@@ -89,8 +89,6 @@ services:
       replicas: 1
 
   webserver:
-    deploy:
-      replicas: 1
     healthcheck:
       test: ["CMD", "echo", "health"]
     secrets:

--- a/services/simcore/docker-compose.deploy.master.yml
+++ b/services/simcore/docker-compose.deploy.master.yml
@@ -27,14 +27,6 @@ services:
         constraints:
           - node.labels.postgres==true
 
-  wb-api-server:
-    deploy:
-      replicas: 3
-
-  webserver:
-    deploy:
-      replicas: 3
-
   redis:
     networks:
       - public

--- a/services/simcore/docker-compose.yml.j2
+++ b/services/simcore/docker-compose.yml.j2
@@ -242,6 +242,7 @@ services:
       - WEBSERVER_LOGLEVEL=${WEBSERVER_LOGLEVEL}
       - WEBSERVER_ANNOUNCEMENTS=${WEBSERVER_ANNOUNCEMENTS}
     deploy:
+      replicas: ${WEBSERVER_REPLICAS}
       labels:
         # ssl header necessary so that socket.io upgrades correctly from polling to websocket mode. the middleware must be attached to the right connection.
         # NOTE: traefik does not like - in the sslheader middleware, so we override it here
@@ -282,6 +283,7 @@ services:
     networks:
       - monitored
     deploy:
+      replicas: ${WB_API_SERVER_REPLICAS}
       update_config:
         <<: *webserver_update_config
       restart_policy:


### PR DESCRIPTION
## What do these changes do?
Explicitly configure replicas (avoid hard code) for some services.

## Related issue/s
* shall relieve https://github.com/ITISFoundation/osparc-ops-environments/issues/1324
* shall relieve https://github.com/ITISFoundation/osparc-ops-environments/issues/1325

## Related PR/s
* https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/merge_requests/1813

## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
