### PR TITLE
Fix: Loki (Remove distroless image healthchecks)

### DIFF
--- a/certificates/Makefile
+++ b/certificates/Makefile
@@ -66,10 +66,16 @@ install-root-certificate: rootca.crt ## installs a certificate in the host syste
 		echo "Is the DOCKER service ready? press when ready" && read -n 1; \
 	    fi;\
 		echo "======================================";,\
-		sudo cp $< /etc/ca-certificates/trust-source/anchors/osparc.crt; \
-		sudo trust extract-compat &&                            \
-		echo "# restarting docker daemon" &&                      \
+		$(if $(IS_OSX),                                             \
+			sudo security add-trusted-cert -d -k /Library/Keychains/System.keychain $<; \
+			echo "Please restart the DOCKER service now..." && read -n 1; \
+			echo "Is the DOCKER service ready? press when ready" && read -n 1; \
+		,                                                           \
+		sudo cp $< /usr/local/share/ca-certificates/osparc.crt; \
+		sudo update-ca-certificates -f;                            \
+		echo "# restarting docker daemon";                      \
 		sudo systemctl restart docker                           \
+		) \
 	)
 
 
@@ -84,8 +90,7 @@ remove-root-certificate: ## removes the certificate from the host system
 		$(if $(IS_OSX), \
 			sudo security remove-trusted-cert -d rootca.crt; \
 		, \
-		sudo rm -f /etc/ca-certificates/trust-source/anchors/osparc.crt; \
-		sudo trust extract-compat; \
-		sudo systemctl restart docker; \
+		sudo rm -f /usr/local/share/ca-certificates/osparc.crt; \
+		sudo update-ca-certificates -f; \
 		) \
 	)


### PR DESCRIPTION
## What do these changes do?
Since 3.5.8., the loki docker image is distroless, which means there is absolutely no shell included. Thus, no healthchecks can be performed as docker implictly runs healthcheck commands in `/bin/sh`.

See: https://grafana.com/docs/loki/latest/setup/upgrade/

<img width="1294" height="631" alt="image" src="https://github.com/user-attachments/assets/b8c5c67f-c98c-4d83-88df-ea5cee2f66d1" />

<img width="1297" height="987" alt="image" src="https://github.com/user-attachments/assets/ac8650f7-98b6-48d9-a04a-968d98e36840" />


The only way feasible in docker (add dependencies on top of the base image) is explicitly not recommended in prod.

The only way to get a healthcheck is a move to k8s is seems



### Bonus:
`stop-first` update policy hopefully makes the restarting of `loki` smoother, as currently it will hang forever since the old container is still exclusively bound to the host port.

## Related issue/s
https://git.speag.com/oSparc/osparc-infra/-/issues/93
## Related PR/s

## Checklist
- [ ] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
