### PR TITLE
Speed up validate simcore settings bash script

### DIFF
--- a/scripts/deployments/validate_simcore_stack_yml.bash
+++ b/scripts/deployments/validate_simcore_stack_yml.bash
@@ -42,9 +42,10 @@ else
     echo "Error: No top-level secrets section found in the Docker Compose file"
     exit 1
 fi
-#
-# start
-#
+
+# pre pull images in parallel to speed up (otherwise images pull 1 by 1 sequentially)
+docker compose --file ${COMPOSE_FILE} pull
+
 for service in $($_yq e '.services | keys | .[]' ${COMPOSE_FILE}); do
     export TARGETNAME=${service#"${SERVICES_PREFIX}"_}
     #  continue if the service == director since it doesnt have settings


### PR DESCRIPTION
## What do these changes do?
Pre pull images before running settings command. It pulls in parallel instead of sequence. Since image pull is most likely taking the most of time (around 3-5 minutes in CI) this shall gain some time in CI Release Pipelines

## Related issue/s

## Related PR/s

## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
