### PR TITLE
Kubernetes: topolvm non ha by default

### DIFF
--- a/charts/topolvm/values.ha.yaml.gotmpl
+++ b/charts/topolvm/values.ha.yaml.gotmpl
@@ -1,0 +1,2 @@
+controller:
+  replicaCount: 2

--- a/charts/topolvm/values.yaml.gotmpl
+++ b/charts/topolvm/values.yaml.gotmpl
@@ -9,6 +9,9 @@ lvmd:
       default: true
       spare-gb: 5
 
+controller:
+  replicaCount: 1
+
 storageClasses:
   - name: {{ .Values.topolvmStorageClassName }}
     storageClass:


### PR DESCRIPTION
## What do these changes do?
Use values.ha.yaml.gotmpl to make it HA. Usecase: in dalco stag atm we have only 1 node. Deploying topolvm without changes from these PR creates to controller pods only one from which can start (1 per node)

## Related issue/s

## Related PR/s
* https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/merge_requests/1850

## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
