### PR TITLE
Kubernetes: fix metrics GUI

### DIFF
--- a/charts/victoria-metrics-distributed/values.yaml.gotmpl
+++ b/charts/victoria-metrics-distributed/values.yaml.gotmpl
@@ -141,7 +141,7 @@ vmdistributed:
           ingress:
             host: {{ requiredEnv "K8S_MONITORING_FQDN" }}
             paths:
-            - /metrics/select/0/vmui
+            - /metrics
             annotations:
               traefik.ingress.kubernetes.io/router.tls: "true"
               traefik.ingress.kubernetes.io/router.entrypoints: websecure


### PR DESCRIPTION
## What do these changes do?
GUI was not showing almost any metrics. The problem is ingress path that was limited to `/metrics/select/0/vmui`. When using GUI, it sends requests at least to `/metrics/select/0/prometheus` and `/metrics/admin/tenants`. Changing ingress path to a more generic value solves the issue. GUI shows metrics now.

<img width="845" height="100" alt="image" src="https://github.com/user-attachments/assets/181345c5-4a0e-4509-b5a3-79f2073266d0" />

Note: grafana was not affected as it uses internal communication (no public ingress)

## Related issue/s

## Related PR/s
* fixes a bug introduced in https://github.com/ITISFoundation/osparc-ops-environments/pull/1349

## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
