### PR TITLE
Kubernetes aws ebs csi: add name to volumes

### DIFF
--- a/charts/aws-ebs-csi-driver/values.yaml.gotmpl
+++ b/charts/aws-ebs-csi-driver/values.yaml.gotmpl
@@ -12,7 +12,7 @@ storageClasses:
     reclaimPolicy: Retain  # EBS Volume will not be deleted when PV is deleted
 
 controller:
-    k8sTagClusterId: k8s-{{ requiredEnv "AWS_DEPLOYMENT_TAG_VALUE" }}
+    k8sTagClusterId: k8s-{{ requiredEnv "AWS_DEPLOYMENT_TAG_VALUE" | replace "." "-"}}
     extraVolumeTags:
         {{ requiredEnv "AWS_DEPLOYMENT_TAG_KEY" }}: {{ requiredEnv "AWS_DEPLOYMENT_TAG_VALUE" }}
     volumeModificationFeature:


### PR DESCRIPTION
## What do these changes do?

Currently, ebs volumes provisioned by AWS EBS CSI have no names. To figure out if volume belongs to kubernetes  cluster, one needs to check volume tags. These changes make AWS EBS CSI provisioner add explicitly name to volumes in format `<cluster-name>-<pv-name>`.

## Related issue/s
* inspired from https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/996

## Related PR/s

## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
