### PR TITLE
Fix: Remove gzip recompression from Docker registry router

### DIFF
--- a/services/registry/docker-compose.yml.j2
+++ b/services/registry/docker-compose.yml.j2
@@ -59,10 +59,14 @@ services:
         - traefik.swarm.network=${PUBLIC_NETWORK}
         # direct access through port
         - traefik.http.services.registry.loadbalancer.server.port=5000
+        # stream large blob transfers immediately instead of buffering
+        - traefik.http.services.registry.loadbalancer.responseforwarding.flushinterval=1ms
         - traefik.http.routers.registry.rule=Host(`${REGISTRY_DOMAIN}`)
         - traefik.http.routers.registry.entrypoints=https
         - traefik.http.routers.registry.tls=true
-        - traefik.http.routers.registry.middlewares=ops_gzip@swarm, ops_auth@swarm
+        # NOTE: ops_gzip removed — Docker image layers are already gzip-compressed;
+        # re-compressing wastes CPU and buffers large blobs in RAM
+        - traefik.http.routers.registry.middlewares=ops_auth@swarm
         - prometheus-job=registry
         - prometheus-port=5001
 


### PR DESCRIPTION
## What do these changes do?

### Problem

Docker image layers are already gzip-compressed (`application/vnd.docker.image.rootfs.diff.tar.gzip`). The registry router was applying `ops_gzip@swarm`, causing Traefik to recompress these binary blobs on every pull — wasting CPU and buffering hundreds of MB in RAM for zero compression benefit.

### Changes

**File:** docker-compose.yml.j2

1. **Removed `ops_gzip@swarm` from the registry middleware chain**
   - Before: `middlewares=ops_gzip@swarm, ops_auth@swarm`
   - After: `middlewares=ops_auth@swarm`

2. **Added `flushinterval=1ms` to the registry loadbalancer**
   - Forces Traefik to stream responses immediately to the Docker client instead of accumulating data, reducing latency on large blob transfers.

### What was NOT changed

- `ops_auth@swarm` remains — registry authentication is preserved.
- No buffering middleware was added — Traefik does not buffer by default, so explicitly disabling it is unnecessary.
- No `Accept-Encoding` header stripping — `ops_gzip` is per-router (not global at the entrypoint level), so simply removing it from the middleware chain is sufficient.
- The pull-through-cache service is unaffected — it binds directly to host port 5000 and does not go through Traefik.

### Expected impact

- Lower CPU usage on Traefik during image pulls
- Lower memory usage (no buffering of compressed blobs)
- Reduced pull latency due to streaming flush

## Related issue/s
- follow up to https://github.com/ITISFoundation/osparc-simcore/issues/8875#issuecomment-4212873859

## Related PR/s

## Checklist
- [ ] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
