### PR TITLE
Charts Makefile: new chart directory from template

### DIFF
--- a/charts/.template/README.md
+++ b/charts/.template/README.md
@@ -1,0 +1,1 @@
+# Chart {{ CHART_NAME }}

--- a/charts/.template/namespace.yaml
+++ b/charts/.template/namespace.yaml
@@ -1,0 +1,8 @@
+# namespace with defined pod security standard
+# ref: https://kubernetes.io/docs/concepts/security/pod-security-standards/
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ CHART_NAME }}
+  labels:
+    pod-security.kubernetes.io/enforce: restricted

--- a/charts/Makefile
+++ b/charts/Makefile
@@ -16,6 +16,9 @@ CHART_DIRS := $(wildcard $(REPO_BASE_DIR)/charts/*/)
 HELMFILE_EXTRA_ARGS ?=
 HELMFILE := helmfile $(HELMFILE_EXTRA_ARGS)
 
+CHART_TEMPLATE_DIR := $(REPO_BASE_DIR)/charts/.template
+CHART_TEMPLATES := $(wildcard $(CHART_TEMPLATE_DIR)/*)
+
 #
 # Helpers
 #
@@ -31,6 +34,16 @@ HELMFILE := helmfile $(HELMFILE_EXTRA_ARGS)
 .helmfile-%: .check-helmfile-installed helmfile.yaml
 	set -a; source $(REPO_CONFIG_LOCATION); set +a; \
 	$(HELMFILE) -f $(REPO_BASE_DIR)/charts/helmfile.yaml $*
+
+.PHONY: add-new-chart
+add-new-chart: guard-CHART_NAME venv ## Adds a new chart folder with standard structure
+	$(eval CHART_DIR := $(REPO_BASE_DIR)/charts/$(CHART_NAME))
+	@mkdir $(CHART_DIR)
+	@echo "CHART_NAME=$(CHART_NAME)" > $(CHART_DIR)/.env
+	@$(foreach tmpl,$(CHART_TEMPLATES),\
+		$(call jinja, $(tmpl), $(CHART_DIR)/.env, $(CHART_DIR)/$(notdir $(tmpl)));\
+	)
+	@rm $(CHART_DIR)/.env
 
 #
 # Artifacts

--- a/charts/Makefile
+++ b/charts/Makefile
@@ -35,8 +35,8 @@ CHART_TEMPLATES := $(wildcard $(CHART_TEMPLATE_DIR)/*)
 	set -a; source $(REPO_CONFIG_LOCATION); set +a; \
 	$(HELMFILE) -f $(REPO_BASE_DIR)/charts/helmfile.yaml $*
 
-.PHONY: add-new-chart-directory
-add-new-chart-directory: guard-CHART_NAME venv ## Adds a new chart directory with standard structure
+.PHONY: add-new-chart-directory-from-template
+add-new-chart-directory-from-template: guard-CHART_NAME venv ## Adds a new chart directory with standard structure
 	$(eval CHART_DIR := $(REPO_BASE_DIR)/charts/$(CHART_NAME))
 	@mkdir $(CHART_DIR)
 	@echo "CHART_NAME=$(CHART_NAME)" > $(CHART_DIR)/.env

--- a/charts/Makefile
+++ b/charts/Makefile
@@ -35,8 +35,8 @@ CHART_TEMPLATES := $(wildcard $(CHART_TEMPLATE_DIR)/*)
 	set -a; source $(REPO_CONFIG_LOCATION); set +a; \
 	$(HELMFILE) -f $(REPO_BASE_DIR)/charts/helmfile.yaml $*
 
-.PHONY: add-new-chart
-add-new-chart: guard-CHART_NAME venv ## Adds a new chart folder with standard structure
+.PHONY: add-new-chart-directory
+add-new-chart-directory: guard-CHART_NAME venv ## Adds a new chart directory with standard structure
 	$(eval CHART_DIR := $(REPO_BASE_DIR)/charts/$(CHART_NAME))
 	@mkdir $(CHART_DIR)
 	@echo "CHART_NAME=$(CHART_NAME)" > $(CHART_DIR)/.env


### PR DESCRIPTION
## What do these changes do?
Add makefile target to create a new chart directory with default structure.

FYI: @matusdrobuliak66 @sanderegg 
## Related issue/s

## Related PR/s

## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
