### PR TITLE
Grafana terraform: update plan target

### DIFF
--- a/services/monitoring/grafana/Makefile
+++ b/services/monitoring/grafana/Makefile
@@ -2,9 +2,10 @@
 REPO_BASE_DIR := $(abspath $(dir $(abspath $(lastword $(MAKEFILE_LIST))))../../..)
 include ${REPO_BASE_DIR}/scripts/common.Makefile
 
+#
+# Variables
+#
 
-
-# Internal VARIABLES ------------------------------------------------
 TF_STATE_FILE := terraform/.terraform/terraform.tfstate
 .PHONY: terraform/main.tf
 terraform/main.tf: terraform/main.tf.j2 venv $(REPO_CONFIG_LOCATION)
@@ -12,6 +13,10 @@ terraform/main.tf: terraform/main.tf.j2 venv $(REPO_CONFIG_LOCATION)
 	@$(call jinja, $<, $(REPO_CONFIG_LOCATION), $@)
 
 terraform-init: $(TF_STATE_FILE)  ## init terraform
+
+#
+# Artifacts
+#
 
 $(TF_STATE_FILE): $(REPO_CONFIG_LOCATION) terraform/main.tf
 	# terraform init
@@ -22,28 +27,10 @@ $(TF_STATE_FILE): $(REPO_CONFIG_LOCATION) terraform/main.tf
 	  terraform -chdir=./terraform init -backend-config="access_key=$${TF_GRAFANA_STATE_BACKEND_AWS_ACCESS_KEY_ID}" -backend-config="secret_key=$${TF_GRAFANA_STATE_BACKEND_AWS_SECRET_ACCESS_KEY}"; \
 	fi
 
+
 terraform/plan.cache:
 	@echo "$@ file not found. Run 'make terraform-plan' to generate it."
 	@exit 1
-
-.PHONY: terraform-plan
-terraform-plan: $(REPO_CONFIG_LOCATION) $(TF_STATE_FILE) ensure-grafana-online assets ## terraform plan
-	# terraform plan
-	@set -a; source $<; set +a; \
-	terraform -chdir=./terraform plan -out=plan.cache
-
-.PHONY: terraform-apply
-terraform-apply: $(REPO_CONFIG_LOCATION) terraform/plan.cache $(TF_STATE_FILE) ensure-grafana-online ## terraform apply
-	# terraform apply
-	@set -a; source $<; set +a; \
-	terraform -chdir=./terraform apply plan.cache
-
-.PHONY: ensure-grafana-online
-ensure-grafana-online: $(WAIT_FOR_IT)
-	@set -o allexport; \
-	source $(REPO_CONFIG_LOCATION); \
-	set +o allexport; \
-	$(WAIT_FOR_IT) http $$TF_VAR_GRAFANA_URL --timeout=120s --interval=5s --expect-status-code 200
 
 .PHONY: assets
 assets: ${REPO_CONFIG_LOCATION}
@@ -59,3 +46,31 @@ assets: ${REPO_CONFIG_LOCATION}
 	mkdir -p $(REPO_BASE_DIR)/services/monitoring/grafana/assets; \
 	cp -r $(shell dirname ${REPO_CONFIG_LOCATION})/../shared/assets/grafana $(REPO_BASE_DIR)/services/monitoring/grafana/assets/shared; \
 	cp -r $(shell dirname ${REPO_CONFIG_LOCATION})/assets/grafana/* $(REPO_BASE_DIR)/services/monitoring/grafana/assets/shared/;
+
+#
+# Targets
+#
+
+.PHONY: terraform-plan
+terraform-plan: $(REPO_CONFIG_LOCATION) \
+				$(TF_STATE_FILE) \
+				ensure-grafana-online \
+				assets \
+				guard-optional-PLAN_EXTRA_ARGS
+terraform-plan: ## terraform plan
+	# terraform plan
+	@set -a; source $<; set +a; \
+	terraform -chdir=./terraform plan -out=plan.cache $(PLAN_EXTRA_ARGS)
+
+.PHONY: terraform-apply
+terraform-apply: $(REPO_CONFIG_LOCATION) terraform/plan.cache $(TF_STATE_FILE) ensure-grafana-online ## terraform apply
+	# terraform apply
+	@set -a; source $<; set +a; \
+	terraform -chdir=./terraform apply plan.cache
+
+.PHONY: ensure-grafana-online
+ensure-grafana-online: $(WAIT_FOR_IT)
+	@set -o allexport; \
+	source $(REPO_CONFIG_LOCATION); \
+	set +o allexport; \
+	$(WAIT_FOR_IT) http $$TF_VAR_GRAFANA_URL --timeout=120s --interval=5s --expect-status-code 200


### PR DESCRIPTION
## What do these changes do?
Add possibility of adding extra plan options. This is to be used to run e2e test verifying grafana test by adding `-detailed-exitcode` option.

## Related issue/s

## Related PR/s
* https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/merge_requests/2006

## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
