### PR TITLE
add env vars to meilisearch

### DIFF
--- a/services/vendors/docker-compose.yml.j2
+++ b/services/vendors/docker-compose.yml.j2
@@ -71,6 +71,9 @@ services:
 {%- raw %}
     hostname: "v-meili-fastapi-{{.Node.Hostname}}-{{.Task.Slot}}"
 {%- endraw %}
+    environment:
+      - MEILISEARCH_HOST=${VENDOR_MEILISEARCH_MEILISEARCH_HOST}
+      - MEILISEARCH_PORT=${VENDOR_MEILISEARCH_MEILISEARCH_PORT}
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8088/health"]
       interval: 30s


### PR DESCRIPTION
## What do these changes do?
- add env vars to meilisearch
## Related issue/s
- https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/merge_requests/2041
## Related PR/s

## Checklist
- [ ] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
