### PR TITLE
add healthceck to meilisearch

### DIFF
--- a/services/vendors/docker-compose.yml.j2
+++ b/services/vendors/docker-compose.yml.j2
@@ -7,6 +7,12 @@ services:
 {%- endraw %}
     environment:
       - FASTAPI_HOST=${VENDOR_MEILI_FASTAPI_HOST}
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:80/web-full/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
     deploy:
       replicas: ${VENDOR_MANUAL_REPLICAS}
       placement:
@@ -43,10 +49,11 @@ services:
     hostname: "v-meilisearch-{{.Node.Hostname}}-{{.Task.Slot}}"
 {%- endraw %}
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:7700/health"]
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:7700/health"]
       interval: 30s
       timeout: 10s
       retries: 3
+      start_period: 10s
     deploy:
       replicas: ${VENDOR_MEILISEARCH_REPLICAS}
       placement:
@@ -81,6 +88,7 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
+      start_period: 10s
     deploy:
       replicas: ${VENDOR_MEILI_FASTAPI_REPLICAS}
       placement:


### PR DESCRIPTION
## What do these changes do?
- adding healthcheck to the meilisearch
## Related issue/s

## Related PR/s

## Checklist
- [ ] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
