### PR TITLE
logging: update ingested fields for (k8s) victoria logs

### DIFF
--- a/services/logging/vector.yaml.j2
+++ b/services/logging/vector.yaml.j2
@@ -57,9 +57,6 @@ transforms:
         del(.created)
       }
 
-      # Add processing metadata
-      .processed_by = "vector"
-
       # Extract structured log fields from message using regex pattern
       if exists(.message) {
         # python service logs
@@ -175,7 +172,7 @@ sinks:
         # or source_type="docker_swarm_logs"
         VL-Extra-Fields: source_type=docker_swarm_logs
         # ignore internal fields to save space (e.g. _command, _image_id, etc.)
-        VL-Ignore-Fields: _*,version,processed_by,port
+        VL-Ignore-Fields: _*,version,port
     {%- if MACHINE_FQDN == "osparc.local" %}
     tls:
       verify_certificate: false

--- a/services/logging/vector.yaml.j2
+++ b/services/logging/vector.yaml.j2
@@ -169,9 +169,12 @@ sinks:
         # first non-empty field from the list is treated as log message
         # WARNING: the message field with value is being renamed to `_msg`
         # (original field key is dropped / not present in VictoriaLogs GUI)
+        # see https://docs.victoriametrics.com/victorialogs/keyconcepts/#message-field
         VL-Msg-Field: log_msg,message
         # log field names, which uniquely identify every log stream
+        # see https://docs.victoriametrics.com/victorialogs/keyconcepts/#stream-fields
         VL-Stream-Fields: source_type,service_name,container_name,container_id
+        # see https://docs.victoriametrics.com/victorialogs/keyconcepts/#time-field
         VL-Time-Field: timestamp
         # WARNING: we overwrite source_type from `socket` to `docker_swarm_logs`
         # This makes more sense to users of victoria logs. Users can use filters

--- a/services/logging/vector.yaml.j2
+++ b/services/logging/vector.yaml.j2
@@ -57,13 +57,6 @@ transforms:
         del(.created)
       }
 
-      # Handle image name
-      if exists(._image_name) {
-        .image_name = ._image_name
-      } else {
-        .image_name = "unknown"
-      }
-
       # Add processing metadata
       .processed_by = "vector"
 
@@ -182,7 +175,7 @@ sinks:
         # or source_type="docker_swarm_logs"
         VL-Extra-Fields: source_type=docker_swarm_logs
         # ignore internal fields to save space (e.g. _command, _image_id, etc.)
-        VL-Ignore-Fields: _*,version,processed_by,port,image_name
+        VL-Ignore-Fields: _*,version,processed_by,port
     {%- if MACHINE_FQDN == "osparc.local" %}
     tls:
       verify_certificate: false

--- a/services/logging/vector.yaml.j2
+++ b/services/logging/vector.yaml.j2
@@ -171,7 +171,7 @@ sinks:
         # (original field key is dropped / not present in VictoriaLogs GUI)
         VL-Msg-Field: log_msg,message
         # log field names, which uniquely identify every log stream
-        VL-Stream-Fields: service_name,container_name,container_id
+        VL-Stream-Fields: source_type,service_name,container_name,container_id
         VL-Time-Field: timestamp
         # WARNING: we overwrite source_type from `socket` to `docker_swarm_logs`
         # This makes more sense to users of victoria logs. Users can use filters
@@ -179,7 +179,7 @@ sinks:
         # or source_type="docker_swarm_logs"
         VL-Extra-Fields: source_type=docker_swarm_logs
         # ignore internal fields to save space (e.g. _command, _image_id, etc.)
-        VL-Ignore-Fields: _*
+        VL-Ignore-Fields: _*,version,processed_by,port,image_name
     {%- if MACHINE_FQDN == "osparc.local" %}
     tls:
       verify_certificate: false


### PR DESCRIPTION
## What do these changes do?
1. Add new stream field `source_type`. This can be used to query docker swarm logs in (k8s) victoria logs more efficient.
* use it via stream filters `{source_type="docker_swarm_logs"}`. Read more https://docs.victoriametrics.com/victorialogs/logsql/#stream-filter
2. Remove fields that do not add useful info. It saves space and probably might improve performance

## Related issue/s

## Related PR/s

## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
