### PR TITLE
draft: scrape syslogs from kubernetes nodes

### DIFF
--- a/charts/victoria-logs/values.yaml.gotmpl
+++ b/charts/victoria-logs/values.yaml.gotmpl
@@ -1,9 +1,83 @@
-# https://github.com/VictoriaMetrics/helm-charts/blob/victoria-logs-single-0.11.2/charts/victoria-logs-single/values.yaml
+# https://github.com/VictoriaMetrics/helm-charts/blob/victoria-logs-single-0.13.6/charts/victoria-logs-single/values.yaml
 
 vector:
   # by default it will generate sink per statefulset's pod
   # each pod has a separate PV, so the data is replicated
   enabled: true
+
+  # Distroless image lacks journalctl, which Vector's `journald` source shells out to.
+  # https://github.com/vectordotdev/vector/issues/19325#issuecomment-2816718363
+  image:
+    base: debian
+
+  customConfig:
+    sources:
+      # Host systemd journal (kubelet, containerd, kernel, ...).
+      # Assumes persistent journald: Storage=persistent in journald.conf
+      # so that /var/log/journal exists on every node. Verify before rollout.
+      journald:
+        type: journald
+        journal_directory: /var/log/journal
+        current_boot_only: true
+
+    transforms:
+      # Trim journald events to a low-cardinality, useful field set.
+      journald_parser:
+        type: remap
+        inputs: [journald]
+        source: |
+          # PRIORITY arrives as string in Vector's journald source.
+          level = to_syslog_level(to_int(.PRIORITY) ?? 6) ?? "unknown"
+
+          # `unit` is a VictoriaLogs stream field, so it must stay low-cardinality:
+          # every distinct value creates a new log stream, and too many streams
+          # degrade ingestion/query performance and inflate disk usage.
+          # systemd uses per-instance unit names for transient units (container
+          # scopes, per-pod slices, user managers, run-* transients) which are
+          # effectively unbounded. We collapse each of those families into a single
+          # stable label while leaving real services (kubelet.service, ...) intact.
+          unit = string(._SYSTEMD_UNIT) ?? string(._TRANSPORT) ?? "unknown"
+          if ends_with(unit, ".scope") {
+            # cri-containerd-<hash>.scope, session-c123.scope, machine-….scope, ...
+            unit = "transient.scope"
+          } else if starts_with(unit, "kubepods") {
+            # kubepods-burstable-pod<UID>.slice lifecycle msgs -> bound the per-pod UID
+            unit = "kubepods.slice"
+          } else if starts_with(unit, "user@") {
+            unit = "user.service"
+          } else if starts_with(unit, "run-") {
+            unit = "transient.service"
+          }
+
+          # see field explanations
+          # https://www.freedesktop.org/software/systemd/man/latest/systemd.journal-fields.html
+          . = {
+            "_msg":              .message,
+            "timestamp":         .timestamp,
+            "host":              .host,
+            "unit":              unit,
+            "syslog_identifier": .SYSLOG_IDENTIFIER,
+            "transport":         ._TRANSPORT,
+            "level":             level,
+            "source_type":       .source_type,
+          }
+
+    sinks:
+      vlogs_journald:
+        type: elasticsearch
+        inputs: [journald_parser]
+        mode: bulk
+        api_version: v8
+        compression: gzip
+        healthcheck:
+          enabled: false
+        request:
+          headers:
+            VL-Time-Field: timestamp
+            VL-Stream-Fields: source_type,host,unit
+            VL-Msg-Field: _msg
+            AccountID: "0"
+            ProjectID: "0"
 
 server:
   replicaCount: 1

--- a/scripts/create_local_k8s_cluster.bash
+++ b/scripts/create_local_k8s_cluster.bash
@@ -52,6 +52,6 @@ kubectl create -f https://raw.githubusercontent.com/projectcalico/calico/v3.30.2
 while ! kubectl get pods -A -l k8s-app=calico-node 2>/dev/null | grep --quiet "Running"; do echo "Waiting for Calico pods to start..."; sleep 1; done
 
 while ! kubectl api-resources --api-group=projectcalico.org | grep --ignore-case networkpolicy >/dev/null 2>&1; do
-    echo "Waiting for Calico API resources to be available (e.g. NetworkPolicy)..."
+    echo "[$(date)] Waiting for Calico API resources to be available (e.g. NetworkPolicy)..."
     sleep 1
 done

--- a/scripts/kind_config.yaml
+++ b/scripts/kind_config.yaml
@@ -20,6 +20,15 @@ nodes:
     labels:
       ops: "true"
       simcore: "true"
+    # kind runs the "node" as a Docker container with its own (volatile) journal,
+    # so /var/log/journal does not exist inside it. Bind-mount the host's
+    # persistent journal into the node at the same path the vector DaemonSet
+    # already reads (node /var/log), so victoria-logs' journald source can scrape
+    # real system logs locally. Read-only: we never want to mutate the host journal.
+    extraMounts:
+      - hostPath: /var/log/journal
+        containerPath: /var/log/journal
+        readOnly: true
 
 # https://archive-os-3-26.netlify.app/calico/3.26/getting-started/kubernetes/kind/
 networking:


### PR DESCRIPTION
## What do these changes do?

## Related issue/s

## Related PR/s

## Checklist
- [ ] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
