### PR TITLE
simcore invitations / datcore-adapter: raise cpu limit to fix failing healthcheck

### DIFF
--- a/services/simcore/docker-compose.yml.j2
+++ b/services/simcore/docker-compose.yml.j2
@@ -224,7 +224,7 @@ services:
           cpus: "0.1"
           memory: "64M"
         limits:
-          cpus: "0.2"
+          cpus: "0.5"
           memory: "256M"
 
   webserver:

--- a/services/simcore/docker-compose.yml.j2
+++ b/services/simcore/docker-compose.yml.j2
@@ -626,7 +626,7 @@ services:
       resources:
         limits:
           memory: 256M
-          cpus: '0.2'
+          cpus: '0.5'
         reservations:
           memory: 128M
           cpus: '0.1'


### PR DESCRIPTION
## What do these changes do?
These service fail to start on master since healthcheck execution takes more than healthcheck timeout. Services can never start. Raising CPU Limit to 0.5 together with changes from the related PR fix this problem

Using 0.5 CPU
<img width="781" height="414" alt="image" src="https://github.com/user-attachments/assets/88fc82f9-3997-4b5f-9dbf-672294d71a89" />

## Related issue/s
* https://github.com/ITISFoundation/osparc-simcore/issues/9182

## Related PR/s
* https://github.com/ITISFoundation/osparc-simcore/pull/9211

## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
