### PR TITLE
Send and keep swarm prometheus metrics in Kubernetes

### DIFF
--- a/charts/victoria-metrics-distributed/templates/ingress-global-write-private.yaml
+++ b/charts/victoria-metrics-distributed/templates/ingress-global-write-private.yaml
@@ -1,0 +1,34 @@
+{{- /*
+Private ingress for the global write entrypoint (vmauth-global-write).
+
+Exposes the Prometheus remote_write endpoint over the internal/private
+Traefik entrypoint so remote Prometheus instances (e.g. on Swarm) can
+push metrics into the VictoriaMetrics distributed cluster.
+*/}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: vmauth-global-write-private
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    # private (VPC-only) entrypoint, not exposed publicly
+    traefik.ingress.kubernetes.io/router.entrypoints: webinternal
+    traefik.ingress.kubernetes.io/router.tls: "true"
+    traefik.ingress.kubernetes.io/router.middlewares: traefik-traefik-basic-auth@kubernetescrd
+  labels:
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: {{ .Chart.Name | trunc 63 }}
+    app.kubernetes.io/instance: {{ .Release.Name | trunc 63 }}
+    helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+spec:
+  rules:
+    - host: {{ .Values.k8sMonitoringPrivateFqdn }}
+      http:
+        paths:
+          - path: /api/v1/write
+            pathType: Prefix
+            backend:
+              service:
+                name: vmauth-{{ .Values.vmdistributed.write.global.vmauth.name }}
+                port:
+                  number: {{ .Values.vmdistributed.common.vmauth.spec.port }}

--- a/charts/victoria-metrics-distributed/values.yaml.gotmpl
+++ b/charts/victoria-metrics-distributed/values.yaml.gotmpl
@@ -1,4 +1,5 @@
 grafanaVictoriaMetricsDatasourceUid: {{ .Values.grafanaVictoriaMetricsDatasourceUid }}
+k8sMonitoringPrivateFqdn: {{ requiredEnv "K8S_MONITORING_PRIVATE_FQDN" }}
 
 vmdistributed:
   fullnameOverride: "vm-distributed"


### PR DESCRIPTION
## What do these changes do?
Changes
* Expose vm-metrics ingress to write metrics from remote

## Related issue/s

## Related PR/s

## Checklist
- [ ] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
