### PR TITLE
Fix kubernetes deploy pipelines

### DIFF
--- a/charts/simcore-charts/.gitkeep
+++ b/charts/simcore-charts/.gitkeep
@@ -1,0 +1,2 @@
+# needed for CI. helmfile.simcore.yaml is copied to this directory.
+# if directory does not exist, copy fail as well as CI Job

--- a/scripts/pre-commit-hooks/check-helmfile-ci-coverage.sh
+++ b/scripts/pre-commit-hooks/check-helmfile-ci-coverage.sh
@@ -3,12 +3,11 @@
 # Ensures every new chart is scanned by the Trivy PR workflow.
 set -euo pipefail
 
-SKIP_RE='^(\.template)$'
 return_code=0
 
 for d in charts/*/; do
   name="$(basename "$d")"
-  [[ "$name" =~ $SKIP_RE ]] && continue
+  [[ "$name" == ".template" || "$name" == "simcore-charts" ]] && continue
   grep -q "${name}/" charts/helmfile.ci.yaml && continue
   echo "Missing in charts/helmfile.ci.yaml: $name" >&2
   return_code=1


### PR DESCRIPTION
## What do these changes do?
Autodeployer in master fails with
```
{
  "changed": false,
  "cmd": "/usr/bin/gmake helmfile-diff",
  "rc": 2,
  "stderr_lines": [
    "/bin/bash: line 1: docker: command not found",
    "/bin/bash: line 1: docker: command not found",
    "cp: cannot create regular file '/<redacted>/osparc-ops/charts/simcore-charts/helmfile.yaml': No such file or directory",
    "gmake: *** [Makefile:56: simcore-charts/helmfile.yaml] Error 1"
  ],
  "stdout": "cp /tmp/z43_o9sam1pyjgqsphz7/osparc-config/deployments/<redacted>/helmfile.simcore.yaml /<redacted>/osparc-ops/charts/simcore-charts/helmfile.yaml\n",
  "stdout_lines": [
    "cp /tmp/z43_o9sam1pyjgqsphz7/osparc-config/deployments/<redacted>/helmfile.simcore.yaml /<redacted>/osparc-ops/charts/simcore-charts/helmfile.yaml"
  ]
}
```


## Related issue/s

## Related PR/s

## Checklist
- [ ] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
