### PR TITLE
Renovate: set minimum release age to 60d

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "schedule": ["* 0-4 * * *"],
   "labels": ["renovate"],
+  "minimumReleaseAge": "60 days",
   "dependencyDashboard": true,
   "enabledManagers": ["helmv3", "helmfile"],
   "helmfile": {


### PR DESCRIPTION
## What do these changes do?
Wait 2 months before updating dependency to reduce risk of supply chain attacks and other potential problems. After 2 months we can be more sure that a new dep version is stable.

Read more at https://docs.renovatebot.com/key-concepts/minimum-release-age/

## Related issue/s

## Related PR/s

## Checklist
- [ ] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
