### PR TITLE
Fix monitoring pgsql-query-exporter wrong image

### DIFF
--- a/services/monitoring/docker-compose.yml.j2
+++ b/services/monitoring/docker-compose.yml.j2
@@ -297,7 +297,7 @@ services:
       - prometheus-port=9400
 
   pgsql-query-exporter:
-    image: ghcr.io/albertodonato/query-exporter:sha-685d8ed
+    image: adonato/query-exporter:5.1.0
     volumes: []
     dns:
       - 8.8.8.8


### PR DESCRIPTION
## What do these changes do?
The previos image+tag combination does not exist anymore. See https://github.com/albertodonato/query-exporter/issues/362 It is also recommend in the issue above to use dockerhub images.

## Related issue/s

## Related PR/s

## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
