### PR TITLE
charts Makefile: verify helmfile version

### DIFF
--- a/.github/workflows/code_static_analysis.yml
+++ b/.github/workflows/code_static_analysis.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Render charts's templates
         uses: helmfile/helmfile-action@v2.4.4
         with:
-          helmfile-version: v0.165.0 # keep in sync with version used in deployments!
+          helmfile-version: v0.165.0 # keep in sync with charts/Makefile and version in running clusters
           helmfile-workdirectory: charts/
           helmfile-auto-init: 'true'
           helmfile-args: >-

--- a/charts/Makefile
+++ b/charts/Makefile
@@ -38,7 +38,7 @@ CHART_TEMPLATES := $(wildcard $(CHART_TEMPLATE_DIR)/*)
 	fi
 	@if ! helmfile --version | grep -q "$(HELMFILE_EXPECTED_VERSION)"; then \
 		echo "WARNING: installed helmfile version does not match"> /dev/stderr; \
-		echo "Expected helmfile version:'$(HELMFILE_EXPECTED_VERSION)'" > /dev/stderr; \
+		echo "Expected helmfile version:'$(HELMFILE_EXPECTED_VERSION)'. Please, update!" > /dev/stderr; \
 		sleep 3s; \
 	fi
 

--- a/charts/Makefile
+++ b/charts/Makefile
@@ -2,7 +2,6 @@
 REPO_BASE_DIR := $(shell git rev-parse --show-toplevel)
 
 include ${REPO_BASE_DIR}/scripts/common.Makefile
-include $(REPO_CONFIG_LOCATION)
 
 #
 # Vars
@@ -10,6 +9,14 @@ include $(REPO_CONFIG_LOCATION)
 
 export CONFIG_DIR := $(shell dirname $(REPO_CONFIG_LOCATION))
 CHART_DIRS := $(wildcard $(REPO_BASE_DIR)/charts/*/)
+
+
+# Helmfile version is dictated by helm version installed in the cluster.
+# Kubepsray dictates the helm version to be installed in the cluster.
+# Based on helm version choose the highest compatible helmfile version.
+# (helmfile defines minimum required helm version)
+# NOTE: keep in sync with github workflows and version in running clusters
+HELMFILE_EXPECTED_VERSION := 0.165.0
 
 # Example of usage:
 # make helmfile-diff HELMFILE_EXTRA_ARGS='--selector app=adminer'
@@ -23,15 +30,20 @@ CHART_TEMPLATES := $(wildcard $(CHART_TEMPLATE_DIR)/*)
 # Helpers
 #
 
-.PHONY: .check-helmfile-installed
-.check-helmfile-installed: ## Checks if helmfile is installed
+.PHONY: .verify-helmfile-installation
+.verify-helmfile-installation:
 	@if ! command -v helmfile >/dev/null 2>&1; then \
-			echo "'helmfile' is not installed. Install it to continue ...";\
+		echo "'helmfile' is not installed. Install version $(HELMFILE_EXPECTED_VERSION) to continue ..."; \
+		exit 1; \
+	fi
+	@if ! helmfile --version | grep -q "$(HELMFILE_EXPECTED_VERSION)"; then \
+		echo "WARNING: installed helmfile version does not match"> /dev/stderr; \
+		echo "Expected helmfile version:'$(HELMFILE_EXPECTED_VERSION)'" > /dev/stderr; \
+		sleep 3s; \
 	fi
 
-
 .PHONY: .helmfile-%
-.helmfile-%: .check-helmfile-installed helmfile.yaml
+.helmfile-%: .verify-helmfile-installation helmfile.yaml
 	set -a; source $(REPO_CONFIG_LOCATION); set +a; \
 	$(HELMFILE) -f $(REPO_BASE_DIR)/charts/helmfile.yaml $*
 


### PR DESCRIPTION
## What do these changes do?

Add a check in makefile verifying installed helmfile version is up-to-date. Print a warning otherwise. 

Add comments and notes about how to choose helmfile version and to keep it in sync with other places

## Related issue/s

## Related PR/s

## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
