### PR TITLE
pre-commit: improve `helm-dependency-update` hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -115,13 +115,12 @@ repos:
         always_run: true
         language: script
         files: '^(.*)\/services\/simcore/(docker-compose.*\.y([a])?ml)$'
-      - id: helm-update-dependencies
+      - id: helm-dependency-update
         name: Helm Dependency Update
-        description: Make sure all Chart.lock files are up-to-date
-        entry: bash -c 'find . -name Chart.yaml -exec dirname {} \; | xargs -t -I% helm dependency update %'
+        description: Make sure Chart.lock files are up-to-date for changed charts
+        entry: bash -c 'set -e; for f; do helm dependency update "$(dirname "$f")"; done' --
         language: system
-        files: ^charts/
-        pass_filenames: false
+        files: ^charts/.*/Chart\.ya?ml$
       - id: helmfile-ci-coverage
         name: Verify that CI helmfile.yaml covers all charts
         entry: scripts/pre-commit-hooks/check-helmfile-ci-coverage.sh


### PR DESCRIPTION
## What do these changes do?
Only run `helm dependence update` when `Chart.yaml` file changed

## Related issue/s

## Related PR/s

## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
