### PR TITLE
Rabbit Cluster: handle network partitions (split brain)

### DIFF
--- a/services/rabbit/Makefile
+++ b/services/rabbit/Makefile
@@ -7,6 +7,7 @@ include ${REPO_BASE_DIR}/scripts/common.Makefile
 # Targets
 #
 
+# All cluster operations (start, stop, etc) are included below
 include ${REPO_BASE_DIR}/services/rabbit/.operations.Makefile
 
 #

--- a/services/rabbit/configs/rabbitmq.conf.j2
+++ b/services/rabbit/configs/rabbitmq.conf.j2
@@ -13,6 +13,15 @@ cluster_formation.classic_config.nodes.{{ ix }} = rabbit@rabbit-node0{{ ix }}_ra
 # important for grafana dashboard to work properly
 cluster_name={{ RABBIT_CLUSTER_NAME }}
 
+# https://www.rabbitmq.com/docs/4.1/partitions#automatic-handling
+# https://www.rabbitmq.com/docs/4.1/partitions#pause-minority
+# In pause-minority mode RabbitMQ will automatically pause cluster nodes
+# which determine themselves to be in a minority  (i.e. fewer or equal
+# than half the total number of nodes). The Erlang VM on the paused nodes
+# will continue running but the nodes will not listen on any ports or be
+# otherwise available)
+cluster_partition_handling = pause_minority
+
 ## Sets the initial quorum queue replica count for newly declared quorum queues.
 ## This value can be overridden using the 'x-quorum-initial-group-size' queue argument
 ## at declaration time.


### PR DESCRIPTION
## What do these changes do?
On on-premise deployments we sometimes get rabbit cluster in split brain state. At some point a particular node cannot reach the other 2 and we end up running (so-to-speak) 2 Rabbit Clusters, since all nodes are running and HA-Proxy (LB) routing to all of them. This breaks clients as they keep connecting to different clusters.

Solution: use cluster partition handling strategy `pause_minority`. In pause-minority mode RabbitMQ will automatically pause cluster nodes which determine themselves to be in a minority. This shall solve the issue

Further read:
* https://www.rabbitmq.com/docs/4.1/partitions#automatic-handling
* https://www.rabbitmq.com/docs/4.1/partitions#pause-minority

Disclaimer:
* we need to keep rabbit cluster running and see how it behaves with a new strategy. I expect cluster to be healthy and coherent when network partition occurs, the 2 nodes that can see each other shall keep running the cluster while 3rd node shall be stopped. e2e-test will later spot this as node3 tests shall fail

## Related issue/s

## Related PR/s

## Checklist
- [ ] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
