### PR TITLE
victoria metrics: set retention for non-ha mode

### DIFF
--- a/charts/victoria-metrics-k8s-stack/values.common.yaml.gotmpl
+++ b/charts/victoria-metrics-k8s-stack/values.common.yaml.gotmpl
@@ -49,6 +49,7 @@ vm-k8s-stack:
     spec:
       port: "8428"
       logLevel: {{ $logLevel }}
+      retentionPeriod: {{ requiredEnv "VICTORIA_METRICS_METRICS_RETENTION_PERIOD" | quote }}
       # served under a path prefix on the ingress; makes VMUI links resolve correctly
       # https://docs.victoriametrics.com/#prefix-for-http-api-endpoints
       extraArgs:


### PR DESCRIPTION
## What do these changes do?
The setting was forgotten missing. It configures data retention. Already done for HA mode and have a corresponding env in repo.config

## Related issue/s

## Related PR/s
* https://github.com/ITISFoundation/osparc-ops-environments/pull/1471

## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
