### PR TITLE
Kubernetes: update node selectors :warning:

### DIFF
--- a/charts/cert-manager/values.common.yaml.gotmpl
+++ b/charts/cert-manager/values.common.yaml.gotmpl
@@ -6,7 +6,7 @@ cert-manager:
     keep: true
 
   nodeSelector:
-    ops: "true"
+    node-role.kubernetes.io/ops: ""
 
   # controller
   replicaCount: 1

--- a/charts/victoria-metrics-k8s-stack/values.common.yaml.gotmpl
+++ b/charts/victoria-metrics-k8s-stack/values.common.yaml.gotmpl
@@ -25,7 +25,7 @@ vm-k8s-stack:
           app.simcore.io/name: vmagent
           app.simcore.io/part-of: {{ .Release.Name }}
       nodeSelector:
-        ops: "true"
+        node-role.kubernetes.io/ops: ""
       resources:
         requests:
           cpu: 50m
@@ -64,7 +64,7 @@ vm-k8s-stack:
           app.simcore.io/name: vmsingle
           app.simcore.io/part-of: {{ .Release.Name }}
       nodeSelector:
-        ops: "true"
+        node-role.kubernetes.io/ops: ""
       resources:
         requests:
           cpu: 100m
@@ -124,7 +124,7 @@ vm-k8s-stack:
     enabled: true
     fullnameOverride: kube-state-metrics-vm-k8s-stack
     nodeSelector:
-      ops: "true"
+      node-role.kubernetes.io/ops: ""
     resources:
       requests:
         cpu: 10m

--- a/charts/victoria-metrics-k8s-stack/values.ha.yaml.gotmpl
+++ b/charts/victoria-metrics-k8s-stack/values.ha.yaml.gotmpl
@@ -51,7 +51,7 @@ vm-k8s-stack:
             app.simcore.io/name: vmstorage
             app.simcore.io/part-of: {{ .Release.Name }}
         nodeSelector:
-          ops: "true"
+          node-role.kubernetes.io/ops: ""
         affinity:
           podAntiAffinity: # enforce that vmstorage pods are not scheduled on the same node
             requiredDuringSchedulingIgnoredDuringExecution:
@@ -90,7 +90,7 @@ vm-k8s-stack:
             app.simcore.io/name: vmselect
             app.simcore.io/part-of: {{ .Release.Name }}
         nodeSelector:
-          ops: "true"
+          node-role.kubernetes.io/ops: ""
         topologySpreadConstraints:
           - maxSkew: 1
             topologyKey: kubernetes.io/hostname
@@ -122,7 +122,7 @@ vm-k8s-stack:
             app.simcore.io/name: vminsert
             app.simcore.io/part-of: {{ .Release.Name }}
         nodeSelector:
-          ops: "true"
+          node-role.kubernetes.io/ops: ""
         topologySpreadConstraints:
           - maxSkew: 1
             topologyKey: kubernetes.io/hostname
@@ -159,7 +159,7 @@ vm-k8s-stack:
           app.simcore.io/name: vmauth
           app.simcore.io/part-of: {{ .Release.Name }}
       nodeSelector:
-        ops: "true"
+        node-role.kubernetes.io/ops: ""
       resources:
         requests:
           cpu: 10m

--- a/charts/victoria-metrics-operator/values.common.yaml.gotmpl
+++ b/charts/victoria-metrics-operator/values.common.yaml.gotmpl
@@ -12,7 +12,7 @@ operator:
   enable_converter_ownership: true
 
 nodeSelector:
-  ops: "true"
+  node-role.kubernetes.io/ops: ""
 
 logLevel: "info" # possible values: info and error.
 

--- a/scripts/create_local_k8s_cluster.bash
+++ b/scripts/create_local_k8s_cluster.bash
@@ -37,6 +37,21 @@ echo "Creating a local Kubernetes cluster named '$KIND_CLUSTER_NAME' using confi
 kind create cluster --config "$KIND_CONFIG_FILE" --name "$KIND_CLUSTER_NAME"
 
 #
+# apply node-role labels
+#
+
+# node-role.kubernetes.io/* labels cannot be self-assigned by the kubelet
+# (NodeRestriction admission), so they must be set via the API after creation.
+# see https://github.com/kubernetes-sigs/kind/issues/3536
+
+echo "Applying node-role labels ..."
+
+kubectl label node --all \
+    node-role.kubernetes.io/ops="" \
+    node-role.kubernetes.io/simcore=""
+
+#
+#
 # install Calico network CNI
 #
 

--- a/scripts/kind_config.yaml
+++ b/scripts/kind_config.yaml
@@ -1,4 +1,3 @@
-# kind-config.yaml
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
@@ -8,9 +7,10 @@ nodes:
         hostPort: 80
       - containerPort: 443
         hostPort: 443
-    labels:
-      ops: "true"
-      simcore: "true"
+    # NOTE: node-role.kubernetes.io/* labels cannot be set here. kind passes
+    # them to the kubelet as --node-labels, but the NodeRestriction admission
+    # plugin rejects self-assigned labels in the node-role.kubernetes.io/
+    # namespace. They are applied via `kubectl label` after cluster creation.
 
 # https://archive-os-3-26.netlify.app/calico/3.26/getting-started/kubernetes/kind/
 networking:


### PR DESCRIPTION
## What do these changes do?
Follow new label format. See changes in the related PR

Manual action required:
* Delete old node labels `kubectl label node --all ops-`

## Related issue/s

## Related PR/s
* https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/merge_requests/2208

## Checklist
- [x] I tested and it works

<!--  Extra checks based on use case -->

<!-- New Stack Introduction
- [ ] The Stack has been included in CI Workflow
-->

<!-- New Service Introduction
- [ ] Service has resource limits and reservations
- [ ] Service has placement constraints or is global
- [ ] Service is restartable
- [ ] Service restart is zero-downtime
- [ ] Service has >1 replicas in PROD
- [ ] Service has docker healthcheck enabled
- [ ] Service is monitored (via prometheus and grafana)
- [ ] Service is not bound to one specific node (e.g. via files or volumes)
- [ ] Relevant OPS E2E Test are added
- [ ] Grafana dashboards updated accordingly

If exposed via traefik
- [ ] Service's Public URL is included in maintenance mode
- [ ] Service's Public URL is included in testing mode
- [ ] Service's has Traefik (Service Loadbalancer) Healthcheck enabled
- [ ] Credentials page is updated
- [ ] Url added to e2e test services (e2e test checking that URL can be accessed)
-->
